### PR TITLE
Initialize Expo app with PWA support

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,26 @@
+name: Deploy Web (GitHub Pages)
+on:
+  push:
+    branches: [ main ]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: npx expo export --platform web
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: dist }
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: { name: github-pages, url: ${{ steps.deployment.outputs.page_url }} }
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+
+# Native
+.kotlin/
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+
+app-example
+
+# generated native folders
+/ios
+/android

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,13 +67,14 @@
 * Restarting the app preserves all entities and practices.
 * The app runs in Expo Go on Android and an emulator.
 
+## Web Preview
+
+* Build static PWA with `npx expo export --platform web`.
+* `.github/workflows/deploy-web.yml` publishes `dist/` to **GitHub Pages** on pushes to `main`.
+
 ## Commands (for the agent)
 
 ```bash
-# scaffold
-npx create-expo-app@latest practice-planner
-cd practice-planner
-
 # run
 npm start
 

--- a/README.md
+++ b/README.md
@@ -33,42 +33,39 @@ Plan practices, track drills, and run sessions with precise, computed start/end 
 
 ```
 /app                 # Expo Router screens
-  /(tabs)/
-  practice/
-  drills/
-  teams/
-  templates/
-  index.tsx
-/db
-  schema.sql         # DDL + migrations (v1)
-/src
-  /models            # TS types for entities
-  /data              # sqlite helpers, repositories
-  /features          # use-cases (createPractice, runPractice, etc.)
-  /ui                # shared components
-  /utils/time.ts     # timeline computations
-assets/
+  index.tsx          # home page
+/db                  # (future) schema and migrations
+/src                 # (future) models, data, features, ui, utils
 README.md
 AGENTS.md
 ```
 
 ### Quick Start
 
-1. **Install Node.js LTS on Windows** (includes npm). ([Node.js][1])
-2. **Create the app (Expo)**:
+1. **Install dependencies**
 
 ```bash
-npx create-expo-app@latest practice-planner
-cd practice-planner
-npm start
+npm install
 ```
 
-This uses `create-expo-app` to scaffold a project (default template includes Expo Router). ([Expo Documentation][2])
+2. **Run on Android or web**
 
-3. **Run on Android**
+```bash
+npm start       # then press 'a' for Android, or 'w' for web
+```
 
-* **Physical device (Expo Go):** With `npm start` running, scan the QR code in **Expo Go**; follow React Native’s “Running on device” guidance. ([React Native][3])
-* **Emulator:** Install Android Studio, create an AVD, then press **a** in the Expo terminal to launch on the emulator. (See setup section below.) ([Expo Documentation][4])
+### Web Preview (PWA)
+
+On pushes to `main`, GitHub Actions builds the web app and deploys it to **GitHub Pages**.
+This makes it easy to open the app on a phone via a URL without installing anything.
+
+To export locally:
+
+```bash
+npx expo export --platform web
+```
+
+The static site is emitted to `dist/` and can be served with any static server.
 
 ### Install SQLite
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,31 @@
+{
+  "expo": {
+    "name": "Practice Planner",
+    "slug": "practice-planner",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "scheme": "practice-planner",
+    "userInterfaceStyle": "automatic",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "edgeToEdgeEnabled": true,
+      "predictiveBackGestureEnabled": false
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "static",
+      "backgroundColor": "#ffffff",
+      "themeColor": "#ffffff"
+    },
+    "plugins": [
+      "expo-router"
+    ],
+    "experiments": {
+      "typedRoutes": true,
+      "reactCompiler": true
+    }
+  }
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function RootLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,0 +1,24 @@
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Practice Planner</Text>
+      <Text>Plan practices and run sessions offline.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,10 @@
+// https://docs.expo.dev/guides/using-eslint/
+const { defineConfig } = require('eslint/config');
+const expoConfig = require('eslint-config-expo/flat');
+
+module.exports = defineConfig([
+  expoConfig,
+  {
+    ignores: ['dist/*'],
+  },
+]);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "practice-planner",
+  "main": "expo-router/entry",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "lint": "expo lint"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^15.0.2",
+    "@react-navigation/bottom-tabs": "^7.4.0",
+    "@react-navigation/elements": "^2.6.3",
+    "@react-navigation/native": "^7.1.8",
+    "expo": "~54.0.7",
+    "expo-constants": "~18.0.8",
+    "expo-font": "~14.0.8",
+    "expo-haptics": "~15.0.7",
+    "expo-image": "~3.0.8",
+    "expo-linking": "~8.0.8",
+    "expo-router": "~6.0.4",
+    "expo-splash-screen": "~31.0.10",
+    "expo-status-bar": "~3.0.8",
+    "expo-symbols": "~1.0.7",
+    "expo-system-ui": "~6.0.7",
+    "expo-web-browser": "~15.0.7",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "react-native": "0.81.4",
+    "react-native-gesture-handler": "~2.28.0",
+    "react-native-worklets": "0.5.1",
+    "react-native-reanimated": "~4.1.0",
+    "react-native-safe-area-context": "~5.6.0",
+    "react-native-screens": "~4.16.0",
+    "react-native-web": "~0.21.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "typescript": "~5.9.2",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~10.0.0"
+  },
+  "private": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    ".expo/types/**/*.ts",
+    "expo-env.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- remove placeholder image assets and references
- simplify Expo config after asset removal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c71a6991ec8323a4c9106530cff48a