### PR TITLE
fix: correct deploy workflow yaml

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -20,7 +20,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: { name: github-pages, url: ${{ steps.deployment.outputs.page_url }} }
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- fix YAML syntax in deploy workflow by expanding environment mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Cannot find module 'eslint/config')*

------
https://chatgpt.com/codex/tasks/task_b_68c7207b520483239cc3d28739037680