### PR TITLE
Add teams and drills CRUD screens

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,11 @@
 import { Stack } from 'expo-router';
+import { DataProvider } from '../src/contexts/DataContext';
 
 export default function RootLayout() {
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <DataProvider>
+      <Stack />
+    </DataProvider>
+  );
 }
+

--- a/app/drills/[id].tsx
+++ b/app/drills/[id].tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function EditDrill() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { drills, updateDrill, removeDrill } = useData();
+  const drill = drills.find(d => d.id === id);
+  const [name, setName] = useState(drill?.name ?? '');
+  const [minutes, setMinutes] = useState(
+    drill ? String(drill.defaultMinutes) : ''
+  );
+  const router = useRouter();
+
+  if (!drill) {
+    return (
+      <View style={styles.container}>
+        <Text>Drill not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput value={name} onChangeText={setName} style={styles.input} />
+      <TextInput
+        value={minutes}
+        onChangeText={setMinutes}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <Button
+        title="Save"
+        onPress={() => {
+          updateDrill(drill.id, name, Number(minutes) || 0);
+          router.back();
+        }}
+      />
+      <View style={styles.spacer} />
+      <Button
+        title="Delete"
+        color="red"
+        onPress={() => {
+          removeDrill(drill.id);
+          router.back();
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  spacer: {
+    height: 12,
+  },
+});

--- a/app/drills/index.tsx
+++ b/app/drills/index.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+import { FlatList, View, Text, Button, StyleSheet } from 'react-native';
+
+export default function DrillsScreen() {
+  const { drills, removeDrill } = useData();
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={drills}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Link href={`/drills/${item.id}`} style={styles.name}>
+              {item.name} ({item.defaultMinutes}m)
+            </Link>
+            <Button title="Delete" onPress={() => removeDrill(item.id)} />
+          </View>
+        )}
+        ListEmptyComponent={<Text>No drills yet</Text>}
+      />
+      <Link href="/drills/new" asChild>
+        <Button title="Add Drill" />
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 18,
+  },
+});

--- a/app/drills/new.tsx
+++ b/app/drills/new.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function NewDrill() {
+  const [name, setName] = useState('');
+  const [minutes, setMinutes] = useState('');
+  const { addDrill } = useData();
+  const router = useRouter();
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Drill name"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Minutes"
+        value={minutes}
+        onChangeText={setMinutes}
+        keyboardType="numeric"
+        style={styles.input}
+      />
+      <Button
+        title="Save"
+        onPress={() => {
+          addDrill(name, Number(minutes) || 0);
+          router.back();
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,10 +1,19 @@
 import { StyleSheet, Text, View } from 'react-native';
+import { Link } from 'expo-router';
 
 export default function HomeScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Practice Planner</Text>
       <Text>Plan practices and run sessions offline.</Text>
+      <View style={styles.links}>
+        <Link href="/teams" style={styles.link}>
+          Manage Teams
+        </Link>
+        <Link href="/drills" style={styles.link}>
+          Manage Drills
+        </Link>
+      </View>
     </View>
   );
 }
@@ -20,5 +29,14 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: 'bold',
     marginBottom: 8,
+  },
+  links: {
+    marginTop: 24,
+    width: '100%',
+  },
+  link: {
+    fontSize: 18,
+    color: 'blue',
+    marginVertical: 8,
   },
 });

--- a/app/teams/[id].tsx
+++ b/app/teams/[id].tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function EditTeam() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { teams, updateTeam, removeTeam } = useData();
+  const team = teams.find(t => t.id === id);
+  const [name, setName] = useState(team?.name ?? '');
+  const router = useRouter();
+
+  if (!team) {
+    return (
+      <View style={styles.container}>
+        <Text>Team not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput value={name} onChangeText={setName} style={styles.input} />
+      <Button
+        title="Save"
+        onPress={() => {
+          updateTeam(team.id, name);
+          router.back();
+        }}
+      />
+      <View style={styles.spacer} />
+      <Button
+        title="Delete"
+        color="red"
+        onPress={() => {
+          removeTeam(team.id);
+          router.back();
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  spacer: {
+    height: 12,
+  },
+});

--- a/app/teams/index.tsx
+++ b/app/teams/index.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+import { FlatList, View, Text, Button, StyleSheet } from 'react-native';
+
+export default function TeamsScreen() {
+  const { teams, removeTeam } = useData();
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={teams}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Link href={`/teams/${item.id}`} style={styles.name}>
+              {item.name}
+            </Link>
+            <Button title="Delete" onPress={() => removeTeam(item.id)} />
+          </View>
+        )}
+        ListEmptyComponent={<Text>No teams yet</Text>}
+      />
+      <Link href="/teams/new" asChild>
+        <Button title="Add Team" />
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 18,
+  },
+});

--- a/app/teams/new.tsx
+++ b/app/teams/new.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function NewTeam() {
+  const [name, setName] = useState('');
+  const { addTeam } = useData();
+  const router = useRouter();
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        placeholder="Team name"
+        value={name}
+        onChangeText={setName}
+        style={styles.input}
+      />
+      <Button
+        title="Save"
+        onPress={() => {
+          addTeam(name);
+          router.back();
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'center',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+});

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type Team = {
+  id: string;
+  name: string;
+};
+
+export type Drill = {
+  id: string;
+  name: string;
+  defaultMinutes: number;
+};
+
+type DataContextType = {
+  teams: Team[];
+  addTeam: (name: string) => void;
+  updateTeam: (id: string, name: string) => void;
+  removeTeam: (id: string) => void;
+  drills: Drill[];
+  addDrill: (name: string, defaultMinutes: number) => void;
+  updateDrill: (id: string, name: string, defaultMinutes: number) => void;
+  removeDrill: (id: string) => void;
+};
+
+const DataContext = createContext<DataContextType | undefined>(undefined);
+
+function id() {
+  return Date.now().toString();
+}
+
+export function DataProvider({ children }: { children: ReactNode }) {
+  const [teams, setTeams] = useState<Team[]>([]);
+  const [drills, setDrills] = useState<Drill[]>([]);
+
+  const addTeam = (name: string) => setTeams(t => [...t, { id: id(), name }]);
+  const updateTeam = (id: string, name: string) =>
+    setTeams(t => t.map(team => (team.id === id ? { ...team, name } : team)));
+  const removeTeam = (id: string) =>
+    setTeams(t => t.filter(team => team.id !== id));
+
+  const addDrill = (name: string, defaultMinutes: number) =>
+    setDrills(d => [...d, { id: id(), name, defaultMinutes }]);
+  const updateDrill = (id: string, name: string, defaultMinutes: number) =>
+    setDrills(d =>
+      d.map(drill =>
+        drill.id === id ? { ...drill, name, defaultMinutes } : drill
+      )
+    );
+  const removeDrill = (id: string) =>
+    setDrills(d => d.filter(drill => drill.id !== id));
+
+  return (
+    <DataContext.Provider
+      value={{ teams, addTeam, updateTeam, removeTeam, drills, addDrill, updateDrill, removeDrill }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+}
+
+export function useData() {
+  const ctx = useContext(DataContext);
+  if (!ctx) throw new Error('useData must be used within DataProvider');
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- add context provider to manage in-memory teams and drills
- add CRUD screens for teams and drills
- link home screen to new management pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c72e4c08488323a3098f761a4c1b95