### PR TITLE
fix expo export web build step

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,8 +15,7 @@ jobs:
         with: { node-version: 20 }
       - run: npm ci
       - run: |
-          npx expo export --platform web \
-            --public-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+          EXPO_BASE_URL=${{ github.event.repository.name }} npx expo export --platform web
           cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with: { path: dist }


### PR DESCRIPTION
## Summary
- remove deprecated `--public-url` flag
- set `EXPO_BASE_URL` so GitHub Pages builds at repository subpath

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `EXPO_BASE_URL=practice-planner npx expo export --platform web`

------
https://chatgpt.com/codex/tasks/task_b_68c7426bacd083238cdc0229a732828c