### PR TITLE
fix expo export web build step

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,8 +15,7 @@ jobs:
         with: { node-version: 20 }
       - run: npm ci
       - run: |
-          npx expo export --platform web \
-            --public-url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/"
+          EXPO_BASE_URL=${{ github.event.repository.name }} npx expo export --platform web
           cp dist/index.html dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with: { path: dist }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,10 +7,10 @@ export default function HomeScreen() {
       <Text style={styles.title}>Practice Planner</Text>
       <Text>Plan practices and run sessions offline.</Text>
       <View style={styles.links}>
-        <Link href="/teams" style={styles.link}>
+        <Link href="teams" style={styles.link}>
           Manage Teams
         </Link>
-        <Link href="/drills" style={styles.link}>
+        <Link href="drills" style={styles.link}>
           Manage Drills
         </Link>
       </View>


### PR DESCRIPTION
## Summary
- remove deprecated `--public-url` flag
- set `EXPO_BASE_URL` so GitHub Pages builds at repository subpath
- link to teams and drills using relative paths so navigation stays within the repository

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `EXPO_BASE_URL=practice-planner npx expo export --platform web`


------
https://chatgpt.com/codex/tasks/task_b_68c7426bacd083238cdc0229a732828c