### PR TITLE
Ensure GitHub Pages serves Expo assets

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -17,6 +17,10 @@ jobs:
       - run: |
           EXPO_BASE_URL=${{ github.event.repository.name }} npx expo export --platform web
           cp dist/index.html dist/404.html
+          # Allow files in directories prefixed with '_' (like _expo/) to be served
+          touch dist/.nojekyll
+          # Prefix asset URLs with the repo name for GitHub Pages
+          find dist -name '*.html' -exec sed -i "s|\"/_expo|\"/${{ github.event.repository.name }}/_expo|g" {} +
       - uses: actions/upload-pages-artifact@v3
         with: { path: dist }
   deploy:


### PR DESCRIPTION
## Summary
- add `.nojekyll` file during web export so `_expo` assets are published
- prefix Expo asset URLs with repository path so GitHub Pages serves them under `/practice-planner`

## Testing
- `npx expo export --platform web`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c7517efc00832383d83c656631cb7a