### PR TITLE
fix: handle GitHub Pages base path

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -21,6 +21,8 @@ jobs:
           touch dist/.nojekyll
           # Prefix asset URLs with the repo name for GitHub Pages
           find dist -name '*.html' -exec sed -i "s|\"/_expo|\"/${{ github.event.repository.name }}/_expo|g" {} +
+          # Strip the repo name from the runtime URL so Expo Router sees '/' instead of '/<repo>'
+          find dist -name '*.html' -exec sed -i "s|<head>|<head><script>var base='/${{ github.event.repository.name }}';if(location.pathname.startsWith(base)){history.replaceState(null,'',location.pathname.slice(base.length)+location.search+location.hash);}</script>|" {} +
       - uses: actions/upload-pages-artifact@v3
         with: { path: dist }
   deploy:


### PR DESCRIPTION
## Summary
- ensure GitHub Pages strips repo prefix so Expo Router routes resolve

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c75ccfecb083238ca352c230f12645