### PR TITLE
fix: handle GitHub Pages base path

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,7 +15,7 @@ jobs:
         with: { node-version: 20 }
       - run: npm ci
       - run: |
-          EXPO_BASE_URL=${{ github.event.repository.name }} npx expo export --platform web
+          EXPO_BASE_URL=/${{ github.event.repository.name }} npx expo export --platform web
           cp dist/index.html dist/404.html
           # Allow files in directories prefixed with '_' (like _expo/) to be served
           touch dist/.nojekyll

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from 'react';
 
 export type Team = {
   id: string;
@@ -31,6 +37,31 @@ function id() {
 export function DataProvider({ children }: { children: ReactNode }) {
   const [teams, setTeams] = useState<Team[]>([]);
   const [drills, setDrills] = useState<Drill[]>([]);
+
+  // Load any saved data on first render
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      const raw = localStorage.getItem('practice-planner:data');
+      if (raw) {
+        const parsed = JSON.parse(raw) as {
+          teams?: Team[];
+          drills?: Drill[];
+        };
+        setTeams(parsed.teams ?? []);
+        setDrills(parsed.drills ?? []);
+      }
+    } catch {}
+  }, []);
+
+  // Persist whenever data changes
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(
+      'practice-planner:data',
+      JSON.stringify({ teams, drills })
+    );
+  }, [teams, drills]);
 
   const addTeam = (name: string) => setTeams(t => [...t, { id: id(), name }]);
   const updateTeam = (id: string, name: string) =>


### PR DESCRIPTION
## Summary
- set Expo export base URL so routes work under repository subpath
- persist teams and drills to localStorage to survive refresh

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c75ccfecb083238ca352c230f12645