### PR TITLE
build(web): serve Expo PWA from subpath

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -15,12 +15,10 @@ jobs:
         with: { node-version: 20 }
       - run: npm ci
       - run: |
-          EXPO_BASE_URL=/${{ github.event.repository.name }} npx expo export --platform web
+          npx expo export --platform web
           cp dist/index.html dist/404.html
           # Allow files in directories prefixed with '_' (like _expo/) to be served
           touch dist/.nojekyll
-          # Prefix asset URLs with the repo name for GitHub Pages
-          find dist -name '*.html' -exec sed -i "s|\"/_expo|\"/${{ github.event.repository.name }}/_expo|g" {} +
       - uses: actions/upload-pages-artifact@v3
         with: { path: dist }
   deploy:

--- a/app.json
+++ b/app.json
@@ -18,14 +18,20 @@
       "bundler": "metro",
       "output": "static",
       "backgroundColor": "#ffffff",
-      "themeColor": "#ffffff"
+      "themeColor": "#ffffff",
+      "startUrl": "/practice-planner/",
+      "scope": "/practice-planner/",
+      "display": "standalone",
+      "name": "Practice Planner",
+      "shortName": "PracticePlanner"
     },
     "plugins": [
       "expo-router"
     ],
     "experiments": {
       "typedRoutes": true,
-      "reactCompiler": true
+      "reactCompiler": true,
+      "baseUrl": "/practice-planner"
     }
   }
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,10 +7,10 @@ export default function HomeScreen() {
       <Text style={styles.title}>Practice Planner</Text>
       <Text>Plan practices and run sessions offline.</Text>
       <View style={styles.links}>
-        <Link href="teams" style={styles.link}>
+        <Link href="/teams" style={styles.link}>
           Manage Teams
         </Link>
-        <Link href="drills" style={styles.link}>
+        <Link href="/drills" style={styles.link}>
           Manage Drills
         </Link>
       </View>

--- a/public/register-service-worker.js
+++ b/public/register-service-worker.js
@@ -1,0 +1,5 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/practice-planner/service-worker.js', { scope: '/practice-planner/' });
+  });
+}


### PR DESCRIPTION
## Summary
- configure experimental `baseUrl` so assets publish under `/practice-planner`
- link to teams and drills with absolute paths for correct routing
- drop unused Webpack override and let Expo handle asset paths

## Testing
- `npm run lint`
- `npx expo export --platform web`


------
https://chatgpt.com/codex/tasks/task_b_68c765ef0d148323b1b493cff490b7d6