### PR TITLE
feat: add practice planner

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,9 @@ export default function HomeScreen() {
         <Link href="/drills" style={styles.link}>
           Manage Drills
         </Link>
+        <Link href="/practices" style={styles.link}>
+          Manage Practices
+        </Link>
       </View>
     </View>
   );

--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -1,0 +1,78 @@
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { useLocalSearchParams, Link, useRouter } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function PracticeView() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { practices, teams, drills, removePractice } = useData();
+  const practice = practices.find((p) => p.id === id);
+  const router = useRouter();
+
+  if (!practice) {
+    return (
+      <View style={styles.container}>
+        <Text>Practice not found</Text>
+      </View>
+    );
+  }
+
+  const team = teams.find((t) => t.id === practice.teamId);
+  const start = new Date(`${practice.date}T${practice.startTime}`);
+  let current = new Date(start);
+  const schedule = practice.drills.map((pd) => {
+    const drill = drills.find((d) => d.id === pd.drillId);
+    const startTime = new Date(current);
+    current = new Date(current.getTime() + pd.minutes * 60000);
+    return { drill, minutes: pd.minutes, startTime };
+  });
+
+  function formatTime(date: Date) {
+    return date.toTimeString().slice(0, 5);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>
+        {team?.name} - {practice.date} {practice.startTime}
+      </Text>
+      {schedule.map((s, idx) => (
+        <Text key={idx} style={styles.row}>
+          {formatTime(s.startTime)} - {s.drill?.name} ({s.minutes}m)
+        </Text>
+      ))}
+      <View style={styles.buttons}>
+        <Link href={`/practices/${practice.id}/edit`} asChild>
+          <Button title="Edit" />
+        </Link>
+        <Button
+          title="Delete"
+          color="red"
+          onPress={() => {
+            removePractice(practice.id);
+            router.back();
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  row: {
+    marginBottom: 8,
+  },
+  buttons: {
+    marginTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+});

--- a/app/practices/[id]/edit.tsx
+++ b/app/practices/[id]/edit.tsx
@@ -1,0 +1,32 @@
+import { View, Text } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import PracticeForm from '../../../src/components/PracticeForm';
+import { useData } from '../../../src/contexts/DataContext';
+
+export default function EditPractice() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { practices, updatePractice } = useData();
+  const practice = practices.find((p) => p.id === id);
+  const router = useRouter();
+
+  if (!practice) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Practice not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <PracticeForm
+      initialTeamId={practice.teamId}
+      initialDate={practice.date}
+      initialStartTime={practice.startTime}
+      initialDrills={practice.drills}
+      onSave={(teamId, date, startTime, drills) => {
+        updatePractice(practice.id, teamId, date, startTime, drills);
+        router.back();
+      }}
+    />
+  );
+}

--- a/app/practices/index.tsx
+++ b/app/practices/index.tsx
@@ -1,0 +1,51 @@
+import { Link } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+import { FlatList, View, Text, Button, StyleSheet } from 'react-native';
+
+export default function PracticesScreen() {
+  const { practices, removePractice, teams } = useData();
+  const sorted = [...practices].sort(
+    (a, b) =>
+      new Date(`${b.date}T${b.startTime}`).getTime() -
+      new Date(`${a.date}T${a.startTime}`).getTime()
+  );
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={sorted}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => {
+          const team = teams.find((t) => t.id === item.teamId);
+          return (
+            <View style={styles.row}>
+              <Link href={`/practices/${item.id}`} style={styles.name}>
+                {item.date} {item.startTime} - {team?.name}
+              </Link>
+              <Button title="Delete" onPress={() => removePractice(item.id)} />
+            </View>
+          );
+        }}
+        ListEmptyComponent={<Text>No practices yet</Text>}
+      />
+      <Link href="/practices/new" asChild>
+        <Button title="Add Practice" />
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 18,
+  },
+});

--- a/app/practices/new.tsx
+++ b/app/practices/new.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'expo-router';
+import PracticeForm from '../../src/components/PracticeForm';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function NewPractice() {
+  const { addPractice } = useData();
+  const router = useRouter();
+  return (
+    <PracticeForm
+      onSave={(teamId, date, startTime, drills) => {
+        addPractice(teamId, date, startTime, drills);
+        router.back();
+      }}
+    />
+  );
+}

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+} from 'react-native';
+import { useData, Drill, PracticeDrill } from '../contexts/DataContext';
+
+export type PracticeFormProps = {
+  initialTeamId?: string;
+  initialDate?: string;
+  initialStartTime?: string;
+  initialDrills?: PracticeDrill[];
+  onSave: (
+    teamId: string,
+    date: string,
+    startTime: string,
+    drills: PracticeDrill[],
+  ) => void;
+};
+
+export default function PracticeForm({
+  initialTeamId,
+  initialDate,
+  initialStartTime,
+  initialDrills,
+  onSave,
+}: PracticeFormProps) {
+  const { teams, drills } = useData();
+  const [teamId, setTeamId] = useState(initialTeamId ?? teams[0]?.id ?? '');
+  const [date, setDate] = useState(initialDate ?? '');
+  const [startTime, setStartTime] = useState(initialStartTime ?? '');
+  const [items, setItems] = useState<{ drillId: string; minutes: string }[]>(
+    (initialDrills ?? []).map((d) => ({ drillId: d.drillId, minutes: String(d.minutes) }))
+  );
+  const [search, setSearch] = useState('');
+
+  const suggestions = drills.filter(
+    (d) =>
+      d.name.toLowerCase().includes(search.toLowerCase()) &&
+      !items.some((i) => i.drillId === d.id)
+  );
+
+  const totalMinutes = items.reduce(
+    (sum, i) => sum + (Number(i.minutes) || 0),
+    0
+  );
+
+  function addDrill(d: Drill) {
+    setItems((prev) => [
+      ...prev,
+      { drillId: d.id, minutes: String(d.defaultMinutes) },
+    ]);
+    setSearch('');
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    setItems((prev) => {
+      const next = [...prev];
+      const tmp = next[index - 1];
+      next[index - 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function moveDown(index: number) {
+    setItems((prev) => {
+      if (index === prev.length - 1) return prev;
+      const next = [...prev];
+      const tmp = next[index + 1];
+      next[index + 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function updateMinutes(index: number, value: string) {
+    setItems((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], minutes: value };
+      return next;
+    });
+  }
+
+  function remove(index: number) {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Team</Text>
+      <View style={styles.teamList}>
+        {teams.map((t) => (
+          <TouchableOpacity
+            key={t.id}
+            onPress={() => setTeamId(t.id)}
+            style={[
+              styles.teamOption,
+              teamId === t.id && styles.teamOptionSelected,
+            ]}
+          >
+            <Text>{t.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <TextInput
+        placeholder="Date (YYYY-MM-DD)"
+        value={date}
+        onChangeText={setDate}
+        style={styles.input}
+      />
+      <TextInput
+        placeholder="Start Time (HH:MM)"
+        value={startTime}
+        onChangeText={setStartTime}
+        style={styles.input}
+      />
+
+      <Text style={styles.total}>Total Minutes: {totalMinutes}</Text>
+
+      <TextInput
+        placeholder="Add drill"
+        value={search}
+        onChangeText={setSearch}
+        style={styles.input}
+      />
+      {search.length > 0 && (
+        <FlatList
+          data={suggestions}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              onPress={() => addDrill(item)}
+              style={styles.suggestion}
+            >
+              <Text>
+                {item.name} ({item.defaultMinutes}m)
+              </Text>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+
+      <FlatList
+        data={items}
+        keyExtractor={(_, i) => String(i)}
+        renderItem={({ item, index }) => {
+          const drill = drills.find((d) => d.id === item.drillId);
+          return (
+            <View style={styles.drillRow}>
+              <Text style={styles.drillName}>{drill?.name}</Text>
+              <TextInput
+                value={item.minutes}
+                onChangeText={(v) => updateMinutes(index, v)}
+                keyboardType="numeric"
+                style={styles.minutesInput}
+              />
+              <View style={styles.rowButtons}>
+                <Button title="↑" onPress={() => moveUp(index)} />
+                <Button title="↓" onPress={() => moveDown(index)} />
+                <Button title="X" onPress={() => remove(index)} />
+              </View>
+            </View>
+          );
+        }}
+      />
+
+      <Button
+        title="Save"
+        onPress={() =>
+          onSave(
+            teamId,
+            date,
+            startTime,
+            items.map((i) => ({
+              drillId: i.drillId,
+              minutes: Number(i.minutes) || 0,
+            }))
+          )
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+  },
+  teamList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginVertical: 8,
+  },
+  teamOption: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginRight: 8,
+    marginBottom: 8,
+  },
+  teamOptionSelected: {
+    backgroundColor: '#def',
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  total: {
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  suggestion: {
+    padding: 8,
+    backgroundColor: '#eee',
+    marginBottom: 4,
+  },
+  drillRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  drillName: {
+    flex: 1,
+  },
+  minutesInput: {
+    width: 60,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 4,
+    marginRight: 8,
+  },
+  rowButtons: {
+    flexDirection: 'row',
+  },
+});

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -17,6 +17,19 @@ export type Drill = {
   defaultMinutes: number;
 };
 
+export type PracticeDrill = {
+  drillId: string;
+  minutes: number;
+};
+
+export type Practice = {
+  id: string;
+  teamId: string;
+  date: string; // YYYY-MM-DD
+  startTime: string; // HH:MM
+  drills: PracticeDrill[];
+};
+
 type DataContextType = {
   teams: Team[];
   addTeam: (name: string) => void;
@@ -26,6 +39,21 @@ type DataContextType = {
   addDrill: (name: string, defaultMinutes: number) => void;
   updateDrill: (id: string, name: string, defaultMinutes: number) => void;
   removeDrill: (id: string) => void;
+  practices: Practice[];
+  addPractice: (
+    teamId: string,
+    date: string,
+    startTime: string,
+    drills: PracticeDrill[]
+  ) => void;
+  updatePractice: (
+    id: string,
+    teamId: string,
+    date: string,
+    startTime: string,
+    drills: PracticeDrill[]
+  ) => void;
+  removePractice: (id: string) => void;
 };
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
@@ -37,6 +65,7 @@ function id() {
 export function DataProvider({ children }: { children: ReactNode }) {
   const [teams, setTeams] = useState<Team[]>([]);
   const [drills, setDrills] = useState<Drill[]>([]);
+  const [practices, setPractices] = useState<Practice[]>([]);
 
   // Load any saved data on first render
   useEffect(() => {
@@ -47,9 +76,11 @@ export function DataProvider({ children }: { children: ReactNode }) {
         const parsed = JSON.parse(raw) as {
           teams?: Team[];
           drills?: Drill[];
+          practices?: Practice[];
         };
         setTeams(parsed.teams ?? []);
         setDrills(parsed.drills ?? []);
+        setPractices(parsed.practices ?? []);
       }
     } catch {}
   }, []);
@@ -59,9 +90,9 @@ export function DataProvider({ children }: { children: ReactNode }) {
     if (typeof localStorage === 'undefined') return;
     localStorage.setItem(
       'practice-planner:data',
-      JSON.stringify({ teams, drills })
+      JSON.stringify({ teams, drills, practices })
     );
-  }, [teams, drills]);
+  }, [teams, drills, practices]);
 
   const addTeam = (name: string) => setTeams(t => [...t, { id: id(), name }]);
   const updateTeam = (id: string, name: string) =>
@@ -80,9 +111,44 @@ export function DataProvider({ children }: { children: ReactNode }) {
   const removeDrill = (id: string) =>
     setDrills(d => d.filter(drill => drill.id !== id));
 
+  const addPractice = (
+    teamId: string,
+    date: string,
+    startTime: string,
+    drills: PracticeDrill[]
+  ) =>
+    setPractices(p => [...p, { id: id(), teamId, date, startTime, drills }]);
+  const updatePractice = (
+    id: string,
+    teamId: string,
+    date: string,
+    startTime: string,
+    drills: PracticeDrill[]
+  ) =>
+    setPractices(p =>
+      p.map(pr =>
+        pr.id === id ? { ...pr, teamId, date, startTime, drills } : pr
+      )
+    );
+  const removePractice = (id: string) =>
+    setPractices(p => p.filter(pr => pr.id !== id));
+
   return (
     <DataContext.Provider
-      value={{ teams, addTeam, updateTeam, removeTeam, drills, addDrill, updateDrill, removeDrill }}
+      value={{
+        teams,
+        addTeam,
+        updateTeam,
+        removeTeam,
+        drills,
+        addDrill,
+        updateDrill,
+        removeDrill,
+        practices,
+        addPractice,
+        updatePractice,
+        removePractice,
+      }}
     >
       {children}
     </DataContext.Provider>


### PR DESCRIPTION
## Summary
- add practices state and CRUD helpers to data context
- implement reusable PracticeForm with drill ordering and totals
- add practice screens for listing, creating, viewing, and editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c7d34054a0832380dfbac0e7e54361