### PR TITLE
Add global header with navigation links

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,11 @@
 import { Stack } from 'expo-router';
 import { DataProvider } from '../src/contexts/DataContext';
+import Header from '../src/components/Header';
 
 export default function RootLayout() {
   return (
     <DataProvider>
-      <Stack />
+      <Stack screenOptions={{ header: () => <Header /> }} />
     </DataProvider>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,49 @@
+import { Link, usePathname } from 'expo-router';
+import { View, StyleSheet } from 'react-native';
+
+export default function Header() {
+  const pathname = usePathname();
+  let listLink = null;
+  if (pathname.startsWith('/teams') && pathname !== '/teams') {
+    listLink = (
+      <Link href="/teams" style={styles.link}>
+        Teams
+      </Link>
+    );
+  } else if (pathname.startsWith('/drills') && pathname !== '/drills') {
+    listLink = (
+      <Link href="/drills" style={styles.link}>
+        Drills
+      </Link>
+    );
+  } else if (pathname.startsWith('/practices') && pathname !== '/practices') {
+    listLink = (
+      <Link href="/practices" style={styles.link}>
+        Practices
+      </Link>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Link href="/" style={styles.link}>
+        Home
+      </Link>
+      {listLink}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    height: 60,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+  },
+  link: {
+    fontSize: 18,
+    color: 'blue',
+  },
+});


### PR DESCRIPTION
## Summary
- add a shared header component with a Home link and context-aware list links
- wire the header into the stack layout for app-wide navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c80383d4cc832390390b177c38b265