### PR TITLE
Use numeric IDs for data entities

### DIFF
--- a/app/drills/[id].tsx
+++ b/app/drills/[id].tsx
@@ -5,8 +5,9 @@ import { useData } from '../../src/contexts/DataContext';
 
 export default function EditDrill() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const drillId = Number(id);
   const { drills, updateDrill, removeDrill } = useData();
-  const drill = drills.find(d => d.id === id);
+  const drill = drills.find(d => d.id === drillId);
   const [name, setName] = useState(drill?.name ?? '');
   const [minutes, setMinutes] = useState(
     drill ? String(drill.defaultMinutes) : ''

--- a/app/drills/index.tsx
+++ b/app/drills/index.tsx
@@ -8,7 +8,7 @@ export default function DrillsScreen() {
     <View style={styles.container}>
       <FlatList
         data={drills}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
           <View style={styles.row}>
             <Link href={`/drills/${item.id}`} style={styles.name}>

--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -4,8 +4,9 @@ import { useData } from '../../src/contexts/DataContext';
 
 export default function PracticeView() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const practiceId = Number(id);
   const { practices, teams, drills, removePractice } = useData();
-  const practice = practices.find((p) => p.id === id);
+  const practice = practices.find((p) => p.id === practiceId);
   const router = useRouter();
 
   if (!practice) {

--- a/app/practices/[id]/edit.tsx
+++ b/app/practices/[id]/edit.tsx
@@ -5,8 +5,9 @@ import { useData } from '../../../src/contexts/DataContext';
 
 export default function EditPractice() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const practiceId = Number(id);
   const { practices, updatePractice } = useData();
-  const practice = practices.find((p) => p.id === id);
+  const practice = practices.find((p) => p.id === practiceId);
   const router = useRouter();
 
   if (!practice) {

--- a/app/practices/index.tsx
+++ b/app/practices/index.tsx
@@ -13,7 +13,7 @@ export default function PracticesScreen() {
     <View style={styles.container}>
       <FlatList
         data={sorted}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => {
           const team = teams.find((t) => t.id === item.teamId);
           return (

--- a/app/teams/[id].tsx
+++ b/app/teams/[id].tsx
@@ -5,8 +5,9 @@ import { useData } from '../../src/contexts/DataContext';
 
 export default function EditTeam() {
   const { id } = useLocalSearchParams<{ id: string }>();
+  const teamId = Number(id);
   const { teams, updateTeam, removeTeam } = useData();
-  const team = teams.find(t => t.id === id);
+  const team = teams.find(t => t.id === teamId);
   const [name, setName] = useState(team?.name ?? '');
   const router = useRouter();
 

--- a/app/teams/index.tsx
+++ b/app/teams/index.tsx
@@ -8,7 +8,7 @@ export default function TeamsScreen() {
     <View style={styles.container}>
       <FlatList
         data={teams}
-        keyExtractor={(item) => item.id}
+        keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
           <View style={styles.row}>
             <Link href={`/teams/${item.id}`} style={styles.name}>

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -21,12 +21,12 @@ const DateTimePicker =
       );
 
 export type PracticeFormProps = {
-  initialTeamId?: string;
+  initialTeamId?: number;
   initialDate?: string;
   initialStartTime?: string;
   initialDrills?: PracticeDrill[];
   onSave: (
-    teamId: string,
+    teamId: number,
     date: string,
     startTime: string,
     drills: PracticeDrill[],
@@ -42,7 +42,9 @@ export default function PracticeForm({
 }: PracticeFormProps) {
   const { teams, drills } = useData();
   const isWeb = Platform.OS === 'web';
-  const [teamId, setTeamId] = useState(initialTeamId ?? teams[0]?.id ?? '');
+  const [teamId, setTeamId] = useState<number>(
+    initialTeamId ?? teams[0]?.id ?? 0,
+  );
   const [date, setDate] = useState<Date>(
     initialDate ? parseDate(initialDate) : new Date()
   );
@@ -51,8 +53,11 @@ export default function PracticeForm({
   );
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimePicker, setShowTimePicker] = useState(false);
-  const [items, setItems] = useState<{ drillId: string; minutes: string }[]>(
-    (initialDrills ?? []).map((d) => ({ drillId: d.drillId, minutes: String(d.minutes) }))
+  const [items, setItems] = useState<{ drillId: number; minutes: string }[]>(
+    (initialDrills ?? []).map((d) => ({
+      drillId: d.drillId,
+      minutes: String(d.minutes),
+    })),
   );
   const [search, setSearch] = useState('');
 
@@ -192,7 +197,7 @@ export default function PracticeForm({
       {search.length > 0 && (
         <FlatList
           data={suggestions}
-          keyExtractor={(item) => item.id}
+          keyExtractor={(item) => item.id.toString()}
           renderItem={({ item }) => (
             <TouchableOpacity
               onPress={() => addDrill(item)}

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -7,24 +7,24 @@ import React, {
 } from 'react';
 
 export type Team = {
-  id: string;
+  id: number;
   name: string;
 };
 
 export type Drill = {
-  id: string;
+  id: number;
   name: string;
   defaultMinutes: number;
 };
 
 export type PracticeDrill = {
-  drillId: string;
+  drillId: number;
   minutes: number;
 };
 
 export type Practice = {
-  id: string;
-  teamId: string;
+  id: number;
+  teamId: number;
   date: string; // YYYY-MM-DD
   startTime: string; // HH:MM
   drills: PracticeDrill[];
@@ -33,33 +33,33 @@ export type Practice = {
 type DataContextType = {
   teams: Team[];
   addTeam: (name: string) => void;
-  updateTeam: (id: string, name: string) => void;
-  removeTeam: (id: string) => void;
+  updateTeam: (id: number, name: string) => void;
+  removeTeam: (id: number) => void;
   drills: Drill[];
   addDrill: (name: string, defaultMinutes: number) => void;
-  updateDrill: (id: string, name: string, defaultMinutes: number) => void;
-  removeDrill: (id: string) => void;
+  updateDrill: (id: number, name: string, defaultMinutes: number) => void;
+  removeDrill: (id: number) => void;
   practices: Practice[];
   addPractice: (
-    teamId: string,
+    teamId: number,
     date: string,
     startTime: string,
-    drills: PracticeDrill[]
+    drills: PracticeDrill[],
   ) => void;
   updatePractice: (
-    id: string,
-    teamId: string,
+    id: number,
+    teamId: number,
     date: string,
     startTime: string,
-    drills: PracticeDrill[]
+    drills: PracticeDrill[],
   ) => void;
-  removePractice: (id: string) => void;
+  removePractice: (id: number) => void;
 };
 
 const DataContext = createContext<DataContextType | undefined>(undefined);
 
 function id() {
-  return Date.now().toString();
+  return Date.now();
 }
 
 const DB_NAME = 'practice-planner';
@@ -80,7 +80,7 @@ function openDb(): Promise<IDBDatabase> {
 async function readState(db: IDBDatabase) {
   return new Promise<
     { teams?: Team[]; drills?: Drill[]; practices?: Practice[] } | undefined
-  >(resolve => {
+  >((resolve) => {
     const tx = db.transaction(STORE_NAME, 'readonly');
     const store = tx.objectStore(STORE_NAME);
     const req = store.get(KEY);
@@ -139,44 +139,48 @@ export function DataProvider({ children }: { children: ReactNode }) {
     saveState({ teams, drills, practices }).catch(() => {});
   }, [teams, drills, practices]);
 
-  const addTeam = (name: string) => setTeams(t => [...t, { id: id(), name }]);
-  const updateTeam = (id: string, name: string) =>
-    setTeams(t => t.map(team => (team.id === id ? { ...team, name } : team)));
-  const removeTeam = (id: string) =>
-    setTeams(t => t.filter(team => team.id !== id));
+  const addTeam = (name: string) =>
+    setTeams((t) => [...t, { id: id(), name }]);
+  const updateTeam = (id: number, name: string) =>
+    setTeams((t) => t.map((team) => (team.id === id ? { ...team, name } : team)));
+  const removeTeam = (id: number) =>
+    setTeams((t) => t.filter((team) => team.id !== id));
 
   const addDrill = (name: string, defaultMinutes: number) =>
-    setDrills(d => [...d, { id: id(), name, defaultMinutes }]);
-  const updateDrill = (id: string, name: string, defaultMinutes: number) =>
-    setDrills(d =>
-      d.map(drill =>
-        drill.id === id ? { ...drill, name, defaultMinutes } : drill
-      )
+    setDrills((d) => [...d, { id: id(), name, defaultMinutes }]);
+  const updateDrill = (id: number, name: string, defaultMinutes: number) =>
+    setDrills((d) =>
+      d.map((drill) =>
+        drill.id === id ? { ...drill, name, defaultMinutes } : drill,
+      ),
     );
-  const removeDrill = (id: string) =>
-    setDrills(d => d.filter(drill => drill.id !== id));
+  const removeDrill = (id: number) =>
+    setDrills((d) => d.filter((drill) => drill.id !== id));
 
   const addPractice = (
-    teamId: string,
+    teamId: number,
     date: string,
     startTime: string,
-    drills: PracticeDrill[]
+    drills: PracticeDrill[],
   ) =>
-    setPractices(p => [...p, { id: id(), teamId, date, startTime, drills }]);
+    setPractices((p) => [
+      ...p,
+      { id: id(), teamId, date, startTime, drills },
+    ]);
   const updatePractice = (
-    id: string,
-    teamId: string,
+    id: number,
+    teamId: number,
     date: string,
     startTime: string,
-    drills: PracticeDrill[]
+    drills: PracticeDrill[],
   ) =>
-    setPractices(p =>
-      p.map(pr =>
-        pr.id === id ? { ...pr, teamId, date, startTime, drills } : pr
-      )
+    setPractices((p) =>
+      p.map((pr) =>
+        pr.id === id ? { ...pr, teamId, date, startTime, drills } : pr,
+      ),
     );
-  const removePractice = (id: string) =>
-    setPractices(p => p.filter(pr => pr.id !== id));
+  const removePractice = (id: number) =>
+    setPractices((p) => p.filter((pr) => pr.id !== id));
 
   return (
     <DataContext.Provider


### PR DESCRIPTION
## Summary
- replace string IDs with integers across teams, drills, practices, and their relationships
- update forms and screens to parse numeric identifiers from URLs and lists

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c81dc03ee083239313ee0da7599508