### PR TITLE
Add practice templates with CRUD and integration

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,6 +16,9 @@ export default function HomeScreen() {
         <Link href="/practices" style={styles.link}>
           Manage Practices
         </Link>
+        <Link href="/templates" style={styles.link}>
+          Manage Templates
+        </Link>
       </View>
     </View>
   );

--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -44,6 +44,9 @@ export default function PracticeView() {
         <Link href={`/practices/${practice.id}/edit`} asChild>
           <Button title="Edit" />
         </Link>
+        <Link href={`/templates/new?practice=${practice.id}`} asChild>
+          <Button title="Save as Template" />
+        </Link>
         <Button
           title="Delete"
           color="red"

--- a/app/templates/[id].tsx
+++ b/app/templates/[id].tsx
@@ -1,0 +1,70 @@
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { useLocalSearchParams, Link, useRouter } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function TemplateView() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { templates, drills, removeTemplate } = useData();
+  const template = templates.find(t => t.id === id);
+  const router = useRouter();
+
+  if (!template) {
+    return (
+      <View style={styles.container}>
+        <Text>Template not found</Text>
+      </View>
+    );
+  }
+
+  let current = 0;
+  const schedule = template.drills.map(pd => {
+    const drill = drills.find(d => d.id === pd.drillId);
+    const start = current;
+    current += pd.minutes;
+    return { drill, minutes: pd.minutes, start };
+  });
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{template.name}</Text>
+      {schedule.map((s, idx) => (
+        <Text key={idx} style={styles.row}>
+          {s.start}m - {s.drill?.name} ({s.minutes}m)
+        </Text>
+      ))}
+      <View style={styles.buttons}>
+        <Link href={`/templates/${template.id}/edit`} asChild>
+          <Button title="Edit" />
+        </Link>
+        <Button
+          title="Delete"
+          color="red"
+          onPress={() => {
+            removeTemplate(template.id);
+            router.back();
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  row: {
+    marginBottom: 8,
+  },
+  buttons: {
+    marginTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+});

--- a/app/templates/[id]/edit.tsx
+++ b/app/templates/[id]/edit.tsx
@@ -1,0 +1,30 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import TemplateForm from '../../../src/components/TemplateForm';
+import { useData } from '../../../src/contexts/DataContext';
+import { View, Text } from 'react-native';
+
+export default function EditTemplate() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const { templates, updateTemplate } = useData();
+  const template = templates.find(t => t.id === id);
+  const router = useRouter();
+
+  if (!template) {
+    return (
+      <View style={{ flex: 1, padding: 16 }}>
+        <Text>Template not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <TemplateForm
+      initialName={template.name}
+      initialDrills={template.drills}
+      onSave={(name, drills) => {
+        updateTemplate(template.id, name, drills);
+        router.back();
+      }}
+    />
+  );
+}

--- a/app/templates/index.tsx
+++ b/app/templates/index.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+import { FlatList, View, Text, Button, StyleSheet } from 'react-native';
+
+export default function TemplatesScreen() {
+  const { templates, removeTemplate } = useData();
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={templates}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Link href={`/templates/${item.id}`} style={styles.name}>
+              {item.name}
+            </Link>
+            <Button title="Delete" onPress={() => removeTemplate(item.id)} />
+          </View>
+        )}
+        ListEmptyComponent={<Text>No templates yet</Text>}
+      />
+      <Link href="/templates/new" asChild>
+        <Button title="Add Template" />
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 18,
+  },
+});

--- a/app/templates/new.tsx
+++ b/app/templates/new.tsx
@@ -1,0 +1,21 @@
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import TemplateForm from '../../src/components/TemplateForm';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function NewTemplate() {
+  const { practice } = useLocalSearchParams<{ practice?: string }>();
+  const { addTemplate, practices } = useData();
+  const router = useRouter();
+  const initialDrills = practice
+    ? practices.find(p => p.id === practice)?.drills
+    : undefined;
+  return (
+    <TemplateForm
+      initialDrills={initialDrills}
+      onSave={(name, drills) => {
+        addTemplate(name, drills);
+        router.back();
+      }}
+    />
+  );
+}

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -40,7 +40,7 @@ export default function PracticeForm({
   initialDrills,
   onSave,
 }: PracticeFormProps) {
-  const { teams, drills } = useData();
+  const { teams, drills, templates } = useData();
   const isWeb = Platform.OS === 'web';
   const [teamId, setTeamId] = useState(initialTeamId ?? teams[0]?.id ?? '');
   const [date, setDate] = useState<Date>(
@@ -111,6 +111,25 @@ export default function PracticeForm({
 
   return (
     <View style={styles.container}>
+      <Text style={styles.label}>Templates</Text>
+      <View style={styles.templateList}>
+        {templates.map(t => (
+          <TouchableOpacity
+            key={t.id}
+            onPress={() =>
+              setItems(
+                t.drills.map(d => ({
+                  drillId: d.drillId,
+                  minutes: String(d.minutes),
+                }))
+              )
+            }
+            style={styles.templateOption}
+          >
+            <Text>{t.name}</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
       <Text style={styles.label}>Team</Text>
       <View style={styles.teamList}>
         {teams.map((t) => (
@@ -270,6 +289,18 @@ const styles = StyleSheet.create({
   },
   teamOptionSelected: {
     backgroundColor: '#def',
+  },
+  templateList: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginBottom: 12,
+  },
+  templateOption: {
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginRight: 8,
+    marginBottom: 8,
   },
   input: {
     borderWidth: 1,

--- a/src/components/TemplateForm.tsx
+++ b/src/components/TemplateForm.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+} from 'react-native';
+import { useData, Drill, PracticeDrill } from '../contexts/DataContext';
+
+export type TemplateFormProps = {
+  initialName?: string;
+  initialDrills?: PracticeDrill[];
+  onSave: (name: string, drills: PracticeDrill[]) => void;
+};
+
+export default function TemplateForm({
+  initialName,
+  initialDrills,
+  onSave,
+}: TemplateFormProps) {
+  const { drills } = useData();
+  const [name, setName] = useState(initialName ?? '');
+  const [items, setItems] = useState<{ drillId: string; minutes: string }[]>(
+    (initialDrills ?? []).map(d => ({ drillId: d.drillId, minutes: String(d.minutes) }))
+  );
+  const [search, setSearch] = useState('');
+
+  const suggestions = drills.filter(
+    d =>
+      d.name.toLowerCase().includes(search.toLowerCase()) &&
+      !items.some(i => i.drillId === d.id)
+  );
+
+  const totalMinutes = items.reduce(
+    (sum, i) => sum + (Number(i.minutes) || 0),
+    0
+  );
+
+  function addDrill(d: Drill) {
+    setItems(prev => [
+      ...prev,
+      { drillId: d.id, minutes: String(d.defaultMinutes) },
+    ]);
+    setSearch('');
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    setItems(prev => {
+      const next = [...prev];
+      const tmp = next[index - 1];
+      next[index - 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function moveDown(index: number) {
+    setItems(prev => {
+      if (index === prev.length - 1) return prev;
+      const next = [...prev];
+      const tmp = next[index + 1];
+      next[index + 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function updateMinutes(index: number, value: string) {
+    setItems(prev => {
+      const next = [...prev];
+      next[index] = { ...next[index], minutes: value };
+      return next;
+    });
+  }
+
+  function remove(index: number) {
+    setItems(prev => prev.filter((_, i) => i !== index));
+  }
+
+  return (
+    <View style={styles.container}>
+      <TextInput
+        value={name}
+        onChangeText={setName}
+        placeholder="Template Name"
+        style={styles.input}
+      />
+      <Text style={styles.total}>Total Minutes: {totalMinutes}</Text>
+      <TextInput
+        placeholder="Add drill"
+        value={search}
+        onChangeText={setSearch}
+        style={styles.input}
+      />
+      {search.length > 0 && (
+        <FlatList
+          data={suggestions}
+          keyExtractor={item => item.id}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              onPress={() => addDrill(item)}
+              style={styles.suggestion}
+            >
+              <Text>
+                {item.name} ({item.defaultMinutes}m)
+              </Text>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+
+      <FlatList
+        data={items}
+        keyExtractor={(_, i) => String(i)}
+        renderItem={({ item, index }) => {
+          const drill = drills.find(d => d.id === item.drillId);
+          return (
+            <View style={styles.drillRow}>
+              <Text style={styles.drillName}>{drill?.name}</Text>
+              <TextInput
+                value={item.minutes}
+                onChangeText={v => updateMinutes(index, v)}
+                keyboardType="numeric"
+                style={styles.minutesInput}
+              />
+              <View style={styles.rowButtons}>
+                <Button title="↑" onPress={() => moveUp(index)} />
+                <Button title="↓" onPress={() => moveDown(index)} />
+                <Button title="X" onPress={() => remove(index)} />
+              </View>
+            </View>
+          );
+        }}
+      />
+
+      <Button
+        title="Save"
+        onPress={() =>
+          onSave(
+            name,
+            items.map(i => ({
+              drillId: i.drillId,
+              minutes: Number(i.minutes) || 0,
+            }))
+          )
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  total: {
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  suggestion: {
+    padding: 8,
+    backgroundColor: '#eee',
+    marginBottom: 4,
+  },
+  drillRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  drillName: {
+    flex: 1,
+  },
+  minutesInput: {
+    width: 60,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 4,
+    marginRight: 8,
+  },
+  rowButtons: {
+    flexDirection: 'row',
+  },
+});
+


### PR DESCRIPTION
## Summary
- add practice template entities with storage and CRUD helpers
- provide TemplateForm and pages to create, view, and edit templates
- allow practices to load drills from templates and save existing practices as templates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c81e4974bc8323b1c81d1e34879cca