### PR TITLE
Add practice templates with CRUD and template-based practice creation

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -16,6 +16,9 @@ export default function HomeScreen() {
         <Link href="/practices" style={styles.link}>
           Manage Practices
         </Link>
+        <Link href="/templates" style={styles.link}>
+          Manage Templates
+        </Link>
       </View>
     </View>
   );

--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -45,6 +45,9 @@ export default function PracticeView() {
         <Link href={`/practices/${practice.id}/edit`} asChild>
           <Button title="Edit" />
         </Link>
+        <Link href={`/templates/new?practiceId=${practice.id}`} asChild>
+          <Button title="Save as Template" />
+        </Link>
         <Button
           title="Delete"
           color="red"

--- a/app/practices/new.tsx
+++ b/app/practices/new.tsx
@@ -1,16 +1,61 @@
+import { useState } from 'react';
+import { View, Text, Button, FlatList, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import PracticeForm from '../../src/components/PracticeForm';
-import { useData } from '../../src/contexts/DataContext';
+import { useData, PracticeDrill } from '../../src/contexts/DataContext';
 
 export default function NewPractice() {
-  const { addPractice } = useData();
+  const { addPractice, templates } = useData();
+  const [templateDrills, setTemplateDrills] = useState<PracticeDrill[] | undefined>(
+    undefined,
+  );
+  const [formKey, setFormKey] = useState(0);
   const router = useRouter();
+
   return (
-    <PracticeForm
-      onSave={(teamId, date, startTime, drills) => {
-        addPractice(teamId, date, startTime, drills);
-        router.back();
-      }}
-    />
+    <View style={{ flex: 1 }}>
+      {templates.length > 0 && (
+        <View style={styles.templates}>
+          <Text style={styles.templatesTitle}>Start from Template:</Text>
+          <FlatList
+            data={templates}
+            keyExtractor={(item) => item.id.toString()}
+            horizontal
+            renderItem={({ item }) => (
+              <View style={styles.templateButton}>
+                <Button
+                  title={item.name}
+                  onPress={() => {
+                    setTemplateDrills(item.drills);
+                    setFormKey((k) => k + 1);
+                  }}
+                />
+              </View>
+            )}
+          />
+        </View>
+      )}
+      <PracticeForm
+        key={formKey}
+        initialDrills={templateDrills}
+        onSave={(teamId, date, startTime, drills) => {
+          addPractice(teamId, date, startTime, drills);
+          router.back();
+        }}
+      />
+    </View>
   );
 }
+
+const styles = StyleSheet.create({
+  templates: {
+    padding: 16,
+  },
+  templatesTitle: {
+    marginBottom: 8,
+    fontWeight: 'bold',
+  },
+  templateButton: {
+    marginRight: 8,
+  },
+});

--- a/app/templates/[id].tsx
+++ b/app/templates/[id].tsx
@@ -1,0 +1,67 @@
+import { View, Text, Button, StyleSheet } from 'react-native';
+import { useLocalSearchParams, Link, useRouter } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function TemplateView() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const templateId = Number(id);
+  const { templates, drills, removeTemplate } = useData();
+  const template = templates.find((t) => t.id === templateId);
+  const router = useRouter();
+
+  if (!template) {
+    return (
+      <View style={styles.container}>
+        <Text>Template not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{template.name}</Text>
+      {template.drills.map((td, idx) => {
+        const drill = drills.find((d) => d.id === td.drillId);
+        return (
+          <Text key={idx} style={styles.row}>
+            {drill?.name} ({td.minutes}m)
+          </Text>
+        );
+      })}
+      <View style={styles.buttons}>
+        <Link href={`/templates/${template.id}/edit`} asChild>
+          <Button title="Edit" />
+        </Link>
+        <Button
+          title="Delete"
+          color="red"
+          onPress={() => {
+            removeTemplate(template.id);
+            router.back();
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  row: {
+    marginBottom: 8,
+  },
+  buttons: {
+    marginTop: 16,
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+});
+

--- a/app/templates/[id]/edit.tsx
+++ b/app/templates/[id]/edit.tsx
@@ -1,0 +1,32 @@
+import { View, Text } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import TemplateForm from '../../../src/components/TemplateForm';
+import { useData } from '../../../src/contexts/DataContext';
+
+export default function EditTemplate() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const templateId = Number(id);
+  const { templates, updateTemplate } = useData();
+  const template = templates.find((t) => t.id === templateId);
+  const router = useRouter();
+
+  if (!template) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <Text>Template not found</Text>
+      </View>
+    );
+  }
+
+  return (
+    <TemplateForm
+      initialName={template.name}
+      initialDrills={template.drills}
+      onSave={(name, drills) => {
+        updateTemplate(template.id, name, drills);
+        router.back();
+      }}
+    />
+  );
+}
+

--- a/app/templates/index.tsx
+++ b/app/templates/index.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'expo-router';
+import { useData } from '../../src/contexts/DataContext';
+import { FlatList, View, Text, Button, StyleSheet } from 'react-native';
+
+export default function TemplatesScreen() {
+  const { templates, removeTemplate } = useData();
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={templates}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <Link href={`/templates/${item.id}`} style={styles.name}>
+              {item.name}
+            </Link>
+            <Button title="Delete" onPress={() => removeTemplate(item.id)} />
+          </View>
+        )}
+        ListEmptyComponent={<Text>No templates yet</Text>}
+      />
+      <Link href="/templates/new" asChild>
+        <Button title="Add Template" />
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 18,
+  },
+});
+

--- a/app/templates/new.tsx
+++ b/app/templates/new.tsx
@@ -1,0 +1,20 @@
+import { useRouter, useLocalSearchParams } from 'expo-router';
+import TemplateForm from '../../src/components/TemplateForm';
+import { useData } from '../../src/contexts/DataContext';
+
+export default function NewTemplate() {
+  const { addTemplate, practices } = useData();
+  const { practiceId } = useLocalSearchParams<{ practiceId?: string }>();
+  const practice = practices.find((p) => p.id === Number(practiceId));
+  const router = useRouter();
+  return (
+    <TemplateForm
+      initialDrills={practice?.drills}
+      onSave={(name, drills) => {
+        addTemplate(name, drills);
+        router.back();
+      }}
+    />
+  );
+}
+

--- a/src/components/TemplateForm.tsx
+++ b/src/components/TemplateForm.tsx
@@ -1,0 +1,195 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  Button,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+} from 'react-native';
+import { useData, Drill, PracticeDrill } from '../contexts/DataContext';
+
+export type TemplateFormProps = {
+  initialName?: string;
+  initialDrills?: PracticeDrill[];
+  onSave: (name: string, drills: PracticeDrill[]) => void;
+};
+
+export default function TemplateForm({
+  initialName = '',
+  initialDrills,
+  onSave,
+}: TemplateFormProps) {
+  const { drills } = useData();
+  const [name, setName] = useState(initialName);
+  const [items, setItems] = useState<{ drillId: number; minutes: string }[]>(
+    (initialDrills ?? []).map((d) => ({
+      drillId: d.drillId,
+      minutes: String(d.minutes),
+    })),
+  );
+  const [search, setSearch] = useState('');
+
+  const suggestions = drills.filter(
+    (d) =>
+      d.name.toLowerCase().includes(search.toLowerCase()) &&
+      !items.some((i) => i.drillId === d.id)
+  );
+
+  const totalMinutes = items.reduce(
+    (sum, i) => sum + (Number(i.minutes) || 0),
+    0
+  );
+
+  function addDrill(d: Drill) {
+    setItems((prev) => [
+      ...prev,
+      { drillId: d.id, minutes: String(d.defaultMinutes) },
+    ]);
+    setSearch('');
+  }
+
+  function moveUp(index: number) {
+    if (index === 0) return;
+    setItems((prev) => {
+      const next = [...prev];
+      const tmp = next[index - 1];
+      next[index - 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function moveDown(index: number) {
+    setItems((prev) => {
+      if (index === prev.length - 1) return prev;
+      const next = [...prev];
+      const tmp = next[index + 1];
+      next[index + 1] = next[index];
+      next[index] = tmp;
+      return next;
+    });
+  }
+
+  function updateMinutes(index: number, value: string) {
+    setItems((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], minutes: value };
+      return next;
+    });
+  }
+
+  function remove(index: number) {
+    setItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.label}>Name</Text>
+      <TextInput value={name} onChangeText={setName} style={styles.input} />
+
+      <Text style={styles.total}>Total Minutes: {totalMinutes}</Text>
+
+      <TextInput
+        placeholder="Add drill"
+        value={search}
+        onChangeText={setSearch}
+        style={styles.input}
+      />
+      {search.length > 0 && (
+        <FlatList
+          data={suggestions}
+          keyExtractor={(item) => item.id.toString()}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              onPress={() => addDrill(item)}
+              style={styles.suggestion}
+            >
+              <Text>{item.name}</Text>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+
+      <FlatList
+        data={items}
+        keyExtractor={(_, idx) => idx.toString()}
+        renderItem={({ item, index }) => {
+          const drill = drills.find((d) => d.id === item.drillId);
+          return (
+            <View style={styles.drillRow}>
+              <Text style={styles.drillName}>{drill?.name}</Text>
+              <TextInput
+                value={item.minutes}
+                onChangeText={(text) => updateMinutes(index, text)}
+                keyboardType="numeric"
+                style={styles.minutesInput}
+              />
+              <View style={styles.buttons}>
+                <Button title="Up" onPress={() => moveUp(index)} />
+                <Button title="Down" onPress={() => moveDown(index)} />
+                <Button title="X" onPress={() => remove(index)} />
+              </View>
+            </View>
+          );
+        }}
+      />
+
+      <Button
+        title="Save"
+        onPress={() =>
+          onSave(
+            name,
+            items.map((i) => ({ drillId: i.drillId, minutes: Number(i.minutes) || 0 }))
+          )
+        }
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+  },
+  total: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  suggestion: {
+    padding: 8,
+    backgroundColor: '#eee',
+    marginBottom: 4,
+  },
+  drillRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  drillName: {
+    flex: 1,
+  },
+  minutesInput: {
+    width: 50,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 4,
+    marginRight: 8,
+  },
+  buttons: {
+    flexDirection: 'row',
+  },
+});
+


### PR DESCRIPTION
## Summary
- introduce `Template` entity with persistence and CRUD actions
- add TemplateForm component and template CRUD pages
- allow saving practices as templates and starting practices from templates

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit` *(fails: src/components/PracticeForm.tsx implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c826f2bc908323b2796be3c8293ad6