### PR TITLE
Add drill descriptions and format practice times

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plan practices, track drills, and run sessions with precise, computed start/end 
 ### Data Model (initial)
 
 * **Category** `{ id, name }`
-* **Drill** `{ id, name, defaultMinutes, categoryIds[] }`
+* **Drill** `{ id, name, defaultMinutes, description }`
 * **Team** `{ id, name }`
 * **Practice** `{ id, teamId, startsAt }`
 * **PracticeDrill** `{ id, practiceId, drillId, minutes, order }`

--- a/app/drills/[id].tsx
+++ b/app/drills/[id].tsx
@@ -12,6 +12,7 @@ export default function EditDrill() {
   const [minutes, setMinutes] = useState(
     drill ? String(drill.defaultMinutes) : ''
   );
+  const [description, setDescription] = useState(drill?.description ?? '');
   const router = useRouter();
 
   if (!drill) {
@@ -31,10 +32,17 @@ export default function EditDrill() {
         keyboardType="numeric"
         style={styles.input}
       />
+      <TextInput
+        value={description}
+        onChangeText={setDescription}
+        multiline
+        numberOfLines={4}
+        style={[styles.input, styles.textArea]}
+      />
       <Button
         title="Save"
         onPress={() => {
-          updateDrill(drill.id, name, Number(minutes) || 0);
+          updateDrill(drill.id, name, Number(minutes) || 0, description.trim());
           router.back();
         }}
       />
@@ -62,6 +70,10 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
     padding: 8,
     marginBottom: 12,
+  },
+  textArea: {
+    minHeight: 80,
+    textAlignVertical: 'top',
   },
   spacer: {
     height: 12,

--- a/app/drills/index.tsx
+++ b/app/drills/index.tsx
@@ -11,9 +11,14 @@ export default function DrillsScreen() {
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
           <View style={styles.row}>
-            <Link href={`/drills/${item.id}`} style={styles.name}>
-              {item.name} ({item.defaultMinutes}m)
-            </Link>
+            <View style={styles.info}>
+              <Link href={`/drills/${item.id}`} style={styles.name}>
+                {item.name} ({item.defaultMinutes}m)
+              </Link>
+              {item.description ? (
+                <Text style={styles.description}>{item.description}</Text>
+              ) : null}
+            </View>
             <Button title="Delete" onPress={() => removeDrill(item.id)} />
           </View>
         )}
@@ -37,7 +42,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 12,
   },
+  info: {
+    flex: 1,
+    marginRight: 12,
+  },
   name: {
     fontSize: 18,
+  },
+  description: {
+    marginTop: 4,
+    color: '#555',
   },
 });

--- a/app/drills/new.tsx
+++ b/app/drills/new.tsx
@@ -6,6 +6,7 @@ import { useData } from '../../src/contexts/DataContext';
 export default function NewDrill() {
   const [name, setName] = useState('');
   const [minutes, setMinutes] = useState('');
+  const [description, setDescription] = useState('');
   const { addDrill } = useData();
   const router = useRouter();
 
@@ -24,10 +25,18 @@ export default function NewDrill() {
         keyboardType="numeric"
         style={styles.input}
       />
+      <TextInput
+        placeholder="Description"
+        value={description}
+        onChangeText={setDescription}
+        style={[styles.input, styles.textArea]}
+        multiline
+        numberOfLines={4}
+      />
       <Button
         title="Save"
         onPress={() => {
-          addDrill(name, Number(minutes) || 0);
+          addDrill(name, Number(minutes) || 0, description.trim());
           router.back();
         }}
       />
@@ -46,5 +55,9 @@ const styles = StyleSheet.create({
     borderColor: '#ccc',
     padding: 8,
     marginBottom: 12,
+  },
+  textArea: {
+    minHeight: 80,
+    textAlignVertical: 'top',
   },
 });

--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -1,6 +1,7 @@
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { useLocalSearchParams, Link, useRouter } from 'expo-router';
 import { useData } from '../../src/contexts/DataContext';
+import { formatTime12Hour } from '../../src/utils/date';
 
 export default function PracticeView() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -27,18 +28,14 @@ export default function PracticeView() {
     return { drill, minutes: pd.minutes, startTime };
   });
 
-  function formatTime(date: Date) {
-    return date.toTimeString().slice(0, 5);
-  }
-
   return (
     <View style={styles.container}>
       <Text style={styles.title}>
-        {team?.name} - {practice.date} {practice.startTime}
+        {team?.name} - {practice.date} {formatTime12Hour(start)}
       </Text>
       {schedule.map((s, idx) => (
         <Text key={idx} style={styles.row}>
-          {formatTime(s.startTime)} - {s.drill?.name} ({s.minutes}m)
+          {formatTime12Hour(s.startTime)} - {s.drill?.name} ({s.minutes}m)
         </Text>
       ))}
       <View style={styles.buttons}>

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   TextInput,
   Button,
+  Alert,
   StyleSheet,
   FlatList,
   TouchableOpacity,
@@ -116,6 +117,14 @@ export default function PracticeForm({
 
   function remove(index: number) {
     setItems((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function showDrillDescription(drill?: Drill) {
+    if (!drill) return;
+    const message = drill.description?.trim()
+      ? drill.description
+      : 'No description provided.';
+    Alert.alert(drill.name, message);
   }
 
   function handleStartTimeChange(text: string) {
@@ -276,9 +285,14 @@ export default function PracticeForm({
               onPress={() => addDrill(item)}
               style={styles.suggestion}
             >
-              <Text>
+              <Text style={styles.suggestionTitle}>
                 {item.name} ({item.defaultMinutes}m)
               </Text>
+              {item.description ? (
+                <Text style={styles.suggestionDescription}>
+                  {item.description}
+                </Text>
+              ) : null}
             </TouchableOpacity>
           )}
         />
@@ -291,7 +305,15 @@ export default function PracticeForm({
           const drill = drills.find((d) => d.id === item.drillId);
           return (
             <View style={styles.drillRow}>
-              <Text style={styles.drillName}>{drill?.name}</Text>
+              <TouchableOpacity
+                style={styles.drillNameButton}
+                onPress={() => showDrillDescription(drill)}
+                disabled={!drill}
+              >
+                <Text style={styles.drillName}>
+                  {drill?.name ?? 'Unknown drill'}
+                </Text>
+              </TouchableOpacity>
               <TextInput
                 value={item.minutes}
                 onChangeText={(v) => updateMinutes(index, v)}
@@ -367,13 +389,25 @@ const styles = StyleSheet.create({
     backgroundColor: '#eee',
     marginBottom: 4,
   },
+  suggestionTitle: {
+    fontWeight: 'bold',
+  },
+  suggestionDescription: {
+    marginTop: 4,
+    color: '#555',
+  },
   drillRow: {
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 8,
   },
+  drillNameButton: {
+    flex: 1,
+    marginRight: 8,
+  },
   drillName: {
     flex: 1,
+    flexShrink: 1,
   },
   minutesInput: {
     width: 60,

--- a/src/components/TemplateForm.tsx
+++ b/src/components/TemplateForm.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   TextInput,
   Button,
+  Alert,
   StyleSheet,
   FlatList,
   TouchableOpacity,
@@ -84,6 +85,14 @@ export default function TemplateForm({
     setItems((prev) => prev.filter((_, i) => i !== index));
   }
 
+  function showDrillDescription(drill?: Drill) {
+    if (!drill) return;
+    const message = drill.description?.trim()
+      ? drill.description
+      : 'No description provided.';
+    Alert.alert(drill.name, message);
+  }
+
   return (
     <View style={styles.container}>
       <Text style={styles.label}>Name</Text>
@@ -106,7 +115,14 @@ export default function TemplateForm({
               onPress={() => addDrill(item)}
               style={styles.suggestion}
             >
-              <Text>{item.name}</Text>
+              <Text style={styles.suggestionTitle}>
+                {item.name} ({item.defaultMinutes}m)
+              </Text>
+              {item.description ? (
+                <Text style={styles.suggestionDescription}>
+                  {item.description}
+                </Text>
+              ) : null}
             </TouchableOpacity>
           )}
         />
@@ -119,7 +135,15 @@ export default function TemplateForm({
           const drill = drills.find((d) => d.id === item.drillId);
           return (
             <View style={styles.drillRow}>
-              <Text style={styles.drillName}>{drill?.name}</Text>
+              <TouchableOpacity
+                style={styles.drillNameButton}
+                onPress={() => showDrillDescription(drill)}
+                disabled={!drill}
+              >
+                <Text style={styles.drillName}>
+                  {drill?.name ?? 'Unknown drill'}
+                </Text>
+              </TouchableOpacity>
               <TextInput
                 value={item.minutes}
                 onChangeText={(text) => updateMinutes(index, text)}
@@ -173,13 +197,25 @@ const styles = StyleSheet.create({
     backgroundColor: '#eee',
     marginBottom: 4,
   },
+  suggestionTitle: {
+    fontWeight: 'bold',
+  },
+  suggestionDescription: {
+    marginTop: 4,
+    color: '#555',
+  },
   drillRow: {
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 8,
   },
+  drillNameButton: {
+    flex: 1,
+    marginRight: 8,
+  },
   drillName: {
     flex: 1,
+    flexShrink: 1,
   },
   minutesInput: {
     width: 50,

--- a/src/contexts/DataContext.tsx
+++ b/src/contexts/DataContext.tsx
@@ -15,6 +15,7 @@ export type Drill = {
   id: number;
   name: string;
   defaultMinutes: number;
+  description: string;
 };
 
 export type PracticeDrill = {
@@ -42,8 +43,17 @@ type DataContextType = {
   updateTeam: (id: number, name: string) => void;
   removeTeam: (id: number) => void;
   drills: Drill[];
-  addDrill: (name: string, defaultMinutes: number) => void;
-  updateDrill: (id: number, name: string, defaultMinutes: number) => void;
+  addDrill: (
+    name: string,
+    defaultMinutes: number,
+    description: string,
+  ) => void;
+  updateDrill: (
+    id: number,
+    name: string,
+    defaultMinutes: number,
+    description: string,
+  ) => void;
   removeDrill: (id: number) => void;
   practices: Practice[];
   addPractice: (
@@ -137,7 +147,12 @@ export function DataProvider({ children }: { children: ReactNode }) {
         const data = await readState(db);
         if (!cancelled && data) {
           setTeams(data.teams ?? []);
-          setDrills(data.drills ?? []);
+          setDrills(
+            (data.drills ?? []).map((drill) => ({
+              ...drill,
+              description: drill.description ?? '',
+            })),
+          );
           setPractices(data.practices ?? []);
           setTemplates(data.templates ?? []);
         }
@@ -164,12 +179,26 @@ export function DataProvider({ children }: { children: ReactNode }) {
   const removeTeam = (id: number) =>
     setTeams((t) => t.filter((team) => team.id !== id));
 
-  const addDrill = (name: string, defaultMinutes: number) =>
-    setDrills((d) => [...d, { id: id(), name, defaultMinutes }]);
-  const updateDrill = (id: number, name: string, defaultMinutes: number) =>
+  const addDrill = (
+    name: string,
+    defaultMinutes: number,
+    description: string,
+  ) =>
+    setDrills((d) => [
+      ...d,
+      { id: id(), name, defaultMinutes, description },
+    ]);
+  const updateDrill = (
+    id: number,
+    name: string,
+    defaultMinutes: number,
+    description: string,
+  ) =>
     setDrills((d) =>
       d.map((drill) =>
-        drill.id === id ? { ...drill, name, defaultMinutes } : drill,
+        drill.id === id
+          ? { ...drill, name, defaultMinutes, description }
+          : drill,
       ),
     );
   const removeDrill = (id: number) =>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -11,6 +11,17 @@ export function formatTime(date: Date): string {
   return `${hours}:${minutes}`;
 }
 
+export function formatTime12Hour(date: Date): string {
+  const rawHours = date.getHours();
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const period = rawHours >= 12 ? 'PM' : 'AM';
+  let hours = rawHours % 12;
+  if (hours === 0) {
+    hours = 12;
+  }
+  return `${hours}:${minutes} ${period}`;
+}
+
 export function parseDate(value: string): Date {
   const [year, month, day] = value.split('-').map(Number);
   return new Date(year, month - 1, day);


### PR DESCRIPTION
## Summary
- add a description field to drills and expose it across the drill CRUD screens
- surface drill descriptions from the practice and template builders via tap-driven popups
- switch the practice detail view schedule to display times in 12-hour AM/PM format

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68c84278a7788323ad65d51f1b42806c