### PR TITLE
Add explicit labels to form inputs

### DIFF
--- a/app/drills/[id].tsx
+++ b/app/drills/[id].tsx
@@ -25,20 +25,33 @@ export default function EditDrill() {
 
   return (
     <View style={styles.container}>
-      <TextInput value={name} onChangeText={setName} style={styles.input} />
-      <TextInput
-        value={minutes}
-        onChangeText={setMinutes}
-        keyboardType="numeric"
-        style={styles.input}
-      />
-      <TextInput
-        value={description}
-        onChangeText={setDescription}
-        multiline
-        numberOfLines={4}
-        style={[styles.input, styles.textArea]}
-      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Drill Name</Text>
+        <TextInput
+          value={name}
+          onChangeText={setName}
+          style={styles.input}
+        />
+      </View>
+      <View style={styles.field}>
+        <Text style={styles.label}>Minutes</Text>
+        <TextInput
+          value={minutes}
+          onChangeText={setMinutes}
+          keyboardType="numeric"
+          style={styles.input}
+        />
+      </View>
+      <View style={styles.field}>
+        <Text style={styles.label}>Description</Text>
+        <TextInput
+          value={description}
+          onChangeText={setDescription}
+          multiline
+          numberOfLines={4}
+          style={[styles.input, styles.textArea]}
+        />
+      </View>
       <Button
         title="Save"
         onPress={() => {
@@ -65,11 +78,17 @@ const styles = StyleSheet.create({
     padding: 16,
     justifyContent: 'center',
   },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
   },
   textArea: {
     minHeight: 80,

--- a/app/drills/new.tsx
+++ b/app/drills/new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useData } from '../../src/contexts/DataContext';
 
@@ -12,27 +12,36 @@ export default function NewDrill() {
 
   return (
     <View style={styles.container}>
-      <TextInput
-        placeholder="Drill name"
-        value={name}
-        onChangeText={setName}
-        style={styles.input}
-      />
-      <TextInput
-        placeholder="Minutes"
-        value={minutes}
-        onChangeText={setMinutes}
-        keyboardType="numeric"
-        style={styles.input}
-      />
-      <TextInput
-        placeholder="Description"
-        value={description}
-        onChangeText={setDescription}
-        style={[styles.input, styles.textArea]}
-        multiline
-        numberOfLines={4}
-      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Drill Name</Text>
+        <TextInput
+          placeholder="Drill name"
+          value={name}
+          onChangeText={setName}
+          style={styles.input}
+        />
+      </View>
+      <View style={styles.field}>
+        <Text style={styles.label}>Minutes</Text>
+        <TextInput
+          placeholder="Minutes"
+          value={minutes}
+          onChangeText={setMinutes}
+          keyboardType="numeric"
+          style={styles.input}
+        />
+      </View>
+      <View style={styles.field}>
+        <Text style={styles.label}>Description</Text>
+        <TextInput
+          placeholder="Description"
+          value={description}
+          onChangeText={setDescription}
+          style={[styles.input, styles.textArea]}
+          multiline
+          numberOfLines={4}
+        />
+      </View>
       <Button
         title="Save"
         onPress={() => {
@@ -50,11 +59,17 @@ const styles = StyleSheet.create({
     padding: 16,
     justifyContent: 'center',
   },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
   },
   textArea: {
     minHeight: 80,

--- a/app/teams/[id].tsx
+++ b/app/teams/[id].tsx
@@ -21,7 +21,10 @@ export default function EditTeam() {
 
   return (
     <View style={styles.container}>
-      <TextInput value={name} onChangeText={setName} style={styles.input} />
+      <View style={styles.field}>
+        <Text style={styles.label}>Team Name</Text>
+        <TextInput value={name} onChangeText={setName} style={styles.input} />
+      </View>
       <Button
         title="Save"
         onPress={() => {
@@ -48,11 +51,17 @@ const styles = StyleSheet.create({
     padding: 16,
     justifyContent: 'center',
   },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
   },
   spacer: {
     height: 12,

--- a/app/teams/new.tsx
+++ b/app/teams/new.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { View, TextInput, Button, StyleSheet } from 'react-native';
+import { View, TextInput, Button, StyleSheet, Text } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useData } from '../../src/contexts/DataContext';
 
@@ -10,12 +10,15 @@ export default function NewTeam() {
 
   return (
     <View style={styles.container}>
-      <TextInput
-        placeholder="Team name"
-        value={name}
-        onChangeText={setName}
-        style={styles.input}
-      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Team Name</Text>
+        <TextInput
+          placeholder="Team name"
+          value={name}
+          onChangeText={setName}
+          style={styles.input}
+        />
+      </View>
       <Button
         title="Save"
         onPress={() => {
@@ -33,10 +36,16 @@ const styles = StyleSheet.create({
     padding: 16,
     justifyContent: 'center',
   },
+  field: {
+    marginBottom: 16,
+  },
+  label: {
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
   },
 });

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -193,89 +193,100 @@ export default function PracticeForm({
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Team</Text>
-      <View style={styles.teamList}>
-        {teams.map((t) => (
-          <TouchableOpacity
-            key={t.id}
-            onPress={() => setTeamId(t.id)}
-            style={[
-              styles.teamOption,
-              teamId === t.id && styles.teamOptionSelected,
-            ]}
-          >
-            <Text>{t.name}</Text>
-          </TouchableOpacity>
-        ))}
+      <View style={styles.field}>
+        <Text style={styles.label}>Team</Text>
+        <View style={styles.teamList}>
+          {teams.map((t) => (
+            <TouchableOpacity
+              key={t.id}
+              onPress={() => setTeamId(t.id)}
+              style={[
+                styles.teamOption,
+                teamId === t.id && styles.teamOptionSelected,
+              ]}
+            >
+              <Text>{t.name}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
       </View>
-      
-      {isWeb ? (
-        <TextInput
-          style={styles.input}
-          value={formatDate(date)}
-          placeholder="YYYY-MM-DD"
-          onChangeText={(text) => setDate(parseDate(text))}
-        />
-      ) : (
-        <View style={styles.picker}>
-          <Button
-            title={`Date: ${formatDate(date)}`}
-            onPress={() => setShowDatePicker(true)}
-          />
-          {showDatePicker && DateTimePicker && (
-            <DateTimePicker
-              value={date}
-              mode="date"
-              display="default"
-              onChange={(_, selected) => {
-                setShowDatePicker(false);
-                if (selected) setDate(selected);
-              }}
-            />
-          )}
-        </View>
-      )}
 
-      {isWeb ? (
-        <TextInput
-          style={styles.input}
-          value={startTimeInput}
-          placeholder="HH:MM"
-          onChangeText={handleStartTimeChange}
-          onBlur={handleStartTimeBlur}
-          maxLength={5}
-        />
-      ) : (
-        <View style={styles.picker}>
-          <Button
-            title={`Start Time: ${formatTime(startTime)}`}
-            onPress={() => setShowTimePicker(true)}
+      <View style={styles.field}>
+        <Text style={styles.label}>Practice Date</Text>
+        {isWeb ? (
+          <TextInput
+            style={styles.input}
+            value={formatDate(date)}
+            placeholder="YYYY-MM-DD"
+            onChangeText={(text) => setDate(parseDate(text))}
           />
-          {showTimePicker && DateTimePicker && (
-            <DateTimePicker
-              value={startTime}
-              mode="time"
-              display="default"
-              onChange={(_, selected) => {
-                setShowTimePicker(false);
-                if (selected) {
-                  setStartTime(selected);
-                  setStartTimeInput(formatTime(selected));
-                }
-              }}
+        ) : (
+          <View style={styles.picker}>
+            <Button
+              title={`Date: ${formatDate(date)}`}
+              onPress={() => setShowDatePicker(true)}
             />
-          )}
-        </View>
-      )}
-      
+            {showDatePicker && DateTimePicker && (
+              <DateTimePicker
+                value={date}
+                mode="date"
+                display="default"
+                onChange={(_, selected) => {
+                  setShowDatePicker(false);
+                  if (selected) setDate(selected);
+                }}
+              />
+            )}
+          </View>
+        )}
+      </View>
+
+      <View style={styles.field}>
+        <Text style={styles.label}>Start Time</Text>
+        {isWeb ? (
+          <TextInput
+            style={styles.input}
+            value={startTimeInput}
+            placeholder="HH:MM"
+            onChangeText={handleStartTimeChange}
+            onBlur={handleStartTimeBlur}
+            maxLength={5}
+          />
+        ) : (
+          <View style={styles.picker}>
+            <Button
+              title={`Start Time: ${formatTime(startTime)}`}
+              onPress={() => setShowTimePicker(true)}
+            />
+            {showTimePicker && DateTimePicker && (
+              <DateTimePicker
+                value={startTime}
+                mode="time"
+                display="default"
+                onChange={(_, selected) => {
+                  setShowTimePicker(false);
+                  if (selected) {
+                    setStartTime(selected);
+                    setStartTimeInput(formatTime(selected));
+                  }
+                }}
+              />
+            )}
+          </View>
+        )}
+      </View>
+
       <Text style={styles.total}>Total Minutes: {totalMinutes}</Text>
 
-      <TextInput
-        placeholder="Add drill"
-        value={search}
-        onChangeText={setSearch}
-        style={styles.input}
-      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Search Drills</Text>
+        <TextInput
+          placeholder="Add drill"
+          value={search}
+          onChangeText={setSearch}
+          style={styles.input}
+        />
+      </View>
       {search.length > 0 && (
         <FlatList
           data={suggestions}
@@ -314,12 +325,15 @@ export default function PracticeForm({
                   {drill?.name ?? 'Unknown drill'}
                 </Text>
               </TouchableOpacity>
-              <TextInput
-                value={item.minutes}
-                onChangeText={(v) => updateMinutes(index, v)}
-                keyboardType="numeric"
-                style={styles.minutesInput}
-              />
+              <View style={styles.minutesContainer}>
+                <Text style={styles.minutesLabel}>Minutes</Text>
+                <TextInput
+                  value={item.minutes}
+                  onChangeText={(v) => updateMinutes(index, v)}
+                  keyboardType="numeric"
+                  style={styles.minutesInput}
+                />
+              </View>
               <View style={styles.rowButtons}>
                 <Button title="↑" onPress={() => moveUp(index)} />
                 <Button title="↓" onPress={() => moveDown(index)} />
@@ -353,13 +367,17 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 16,
   },
+  field: {
+    marginBottom: 16,
+  },
   label: {
     fontWeight: 'bold',
+    marginBottom: 4,
   },
   teamList: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    marginVertical: 8,
+    marginTop: 8,
   },
   teamOption: {
     padding: 8,
@@ -375,10 +393,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
+    marginBottom: 0,
   },
   picker: {
-    marginBottom: 12,
+    marginTop: 4,
   },
   total: {
     fontWeight: 'bold',
@@ -414,7 +432,15 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 4,
+    marginRight: 0,
+  },
+  minutesContainer: {
+    width: 70,
     marginRight: 8,
+  },
+  minutesLabel: {
+    fontWeight: 'bold',
+    marginBottom: 4,
   },
   rowButtons: {
     flexDirection: 'row',

--- a/src/components/TemplateForm.tsx
+++ b/src/components/TemplateForm.tsx
@@ -95,17 +95,22 @@ export default function TemplateForm({
 
   return (
     <View style={styles.container}>
-      <Text style={styles.label}>Name</Text>
-      <TextInput value={name} onChangeText={setName} style={styles.input} />
+      <View style={styles.field}>
+        <Text style={styles.label}>Name</Text>
+        <TextInput value={name} onChangeText={setName} style={styles.input} />
+      </View>
 
       <Text style={styles.total}>Total Minutes: {totalMinutes}</Text>
 
-      <TextInput
-        placeholder="Add drill"
-        value={search}
-        onChangeText={setSearch}
-        style={styles.input}
-      />
+      <View style={styles.field}>
+        <Text style={styles.label}>Search Drills</Text>
+        <TextInput
+          placeholder="Add drill"
+          value={search}
+          onChangeText={setSearch}
+          style={styles.input}
+        />
+      </View>
       {search.length > 0 && (
         <FlatList
           data={suggestions}
@@ -144,12 +149,15 @@ export default function TemplateForm({
                   {drill?.name ?? 'Unknown drill'}
                 </Text>
               </TouchableOpacity>
-              <TextInput
-                value={item.minutes}
-                onChangeText={(text) => updateMinutes(index, text)}
-                keyboardType="numeric"
-                style={styles.minutesInput}
-              />
+              <View style={styles.minutesContainer}>
+                <Text style={styles.minutesLabel}>Minutes</Text>
+                <TextInput
+                  value={item.minutes}
+                  onChangeText={(text) => updateMinutes(index, text)}
+                  keyboardType="numeric"
+                  style={styles.minutesInput}
+                />
+              </View>
               <View style={styles.buttons}>
                 <Button title="Up" onPress={() => moveUp(index)} />
                 <Button title="Down" onPress={() => moveDown(index)} />
@@ -178,6 +186,9 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 16,
   },
+  field: {
+    marginBottom: 16,
+  },
   label: {
     fontWeight: 'bold',
     marginBottom: 4,
@@ -186,7 +197,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 8,
-    marginBottom: 12,
+    marginBottom: 0,
   },
   total: {
     fontWeight: 'bold',
@@ -222,7 +233,15 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#ccc',
     padding: 4,
+    marginRight: 0,
+  },
+  minutesContainer: {
+    width: 70,
     marginRight: 8,
+  },
+  minutesLabel: {
+    fontWeight: 'bold',
+    marginBottom: 4,
   },
   buttons: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- add explicit labels to drill and team create/edit forms so fields remain clear when filled
- introduce labeled wrappers for practice and template forms, including inline minute editors, to improve clarity across the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68c84f906f948323b24f50dc316cf901