### PR TITLE
Fix drill description alerts on web

### DIFF
--- a/app/practices/[id].tsx
+++ b/app/practices/[id].tsx
@@ -2,6 +2,7 @@ import { View, Text, Button, StyleSheet } from 'react-native';
 import { useLocalSearchParams, Link, useRouter } from 'expo-router';
 import { useData } from '../../src/contexts/DataContext';
 import { formatTime12Hour } from '../../src/utils/date';
+import { showDrillDescription } from '../../src/utils/showDrillDescription';
 
 export default function PracticeView() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -34,9 +35,20 @@ export default function PracticeView() {
         {team?.name} - {practice.date} {formatTime12Hour(start)}
       </Text>
       {schedule.map((s, idx) => (
-        <Text key={idx} style={styles.row}>
-          {formatTime12Hour(s.startTime)} - {s.drill?.name} ({s.minutes}m)
-        </Text>
+        <View key={idx} style={styles.row}>
+          <Text style={styles.rowText}>
+            {formatTime12Hour(s.startTime)} -
+            {' '}
+            {s.drill?.name ?? 'Unknown drill'} ({s.minutes}m)
+          </Text>
+          <View style={styles.descriptionButton}>
+            <Button
+              title="View Description"
+              onPress={() => showDrillDescription(s.drill)}
+              disabled={!s.drill}
+            />
+          </View>
+        </View>
       ))}
       <View style={styles.buttons}>
         <Link href={`/practices/${practice.id}/edit`} asChild>
@@ -70,6 +82,15 @@ const styles = StyleSheet.create({
   },
   row: {
     marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rowText: {
+    flex: 1,
+    marginRight: 12,
+  },
+  descriptionButton: {
+    marginLeft: 4,
   },
   buttons: {
     marginTop: 16,

--- a/app/templates/[id].tsx
+++ b/app/templates/[id].tsx
@@ -1,6 +1,7 @@
 import { View, Text, Button, StyleSheet } from 'react-native';
 import { useLocalSearchParams, Link, useRouter } from 'expo-router';
 import { useData } from '../../src/contexts/DataContext';
+import { showDrillDescription } from '../../src/utils/showDrillDescription';
 
 export default function TemplateView() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -23,9 +24,18 @@ export default function TemplateView() {
       {template.drills.map((td, idx) => {
         const drill = drills.find((d) => d.id === td.drillId);
         return (
-          <Text key={idx} style={styles.row}>
-            {drill?.name} ({td.minutes}m)
-          </Text>
+          <View key={idx} style={styles.row}>
+            <Text style={styles.rowText}>
+              {drill?.name ?? 'Unknown drill'} ({td.minutes}m)
+            </Text>
+            <View style={styles.descriptionButton}>
+              <Button
+                title="View Description"
+                onPress={() => showDrillDescription(drill)}
+                disabled={!drill}
+              />
+            </View>
+          </View>
         );
       })}
       <View style={styles.buttons}>
@@ -57,6 +67,15 @@ const styles = StyleSheet.create({
   },
   row: {
     marginBottom: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  rowText: {
+    flex: 1,
+    marginRight: 12,
+  },
+  descriptionButton: {
+    marginLeft: 4,
   },
   buttons: {
     marginTop: 16,

--- a/src/components/PracticeForm.tsx
+++ b/src/components/PracticeForm.tsx
@@ -4,7 +4,6 @@ import {
   Text,
   TextInput,
   Button,
-  Alert,
   StyleSheet,
   FlatList,
   TouchableOpacity,
@@ -12,6 +11,7 @@ import {
 } from 'react-native';
 import { useData, Drill, PracticeDrill } from '../contexts/DataContext';
 import { formatDate, formatTime, parseDate, parseTime } from '../utils/date';
+import { showDrillDescription } from '../utils/showDrillDescription';
 // DateTimePicker is not available on web, so require dynamically
 const DateTimePicker =
   Platform.OS === 'web'
@@ -117,14 +117,6 @@ export default function PracticeForm({
 
   function remove(index: number) {
     setItems((prev) => prev.filter((_, i) => i !== index));
-  }
-
-  function showDrillDescription(drill?: Drill) {
-    if (!drill) return;
-    const message = drill.description?.trim()
-      ? drill.description
-      : 'No description provided.';
-    Alert.alert(drill.name, message);
   }
 
   function handleStartTimeChange(text: string) {

--- a/src/components/TemplateForm.tsx
+++ b/src/components/TemplateForm.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   TextInput,
   Button,
-  Alert,
   StyleSheet,
   FlatList,
   TouchableOpacity,
 } from 'react-native';
 import { useData, Drill, PracticeDrill } from '../contexts/DataContext';
+import { showDrillDescription } from '../utils/showDrillDescription';
 
 export type TemplateFormProps = {
   initialName?: string;
@@ -83,14 +83,6 @@ export default function TemplateForm({
 
   function remove(index: number) {
     setItems((prev) => prev.filter((_, i) => i !== index));
-  }
-
-  function showDrillDescription(drill?: Drill) {
-    if (!drill) return;
-    const message = drill.description?.trim()
-      ? drill.description
-      : 'No description provided.';
-    Alert.alert(drill.name, message);
   }
 
   return (

--- a/src/utils/showDrillDescription.ts
+++ b/src/utils/showDrillDescription.ts
@@ -1,0 +1,24 @@
+import { Alert, Platform } from 'react-native';
+import type { Drill } from '../contexts/DataContext';
+
+const DEFAULT_MESSAGE = 'No description provided.';
+
+export function showDrillDescription(drill?: Pick<Drill, 'name' | 'description'>) {
+  if (!drill) {
+    return;
+  }
+
+  const message = drill.description?.trim() ? drill.description : DEFAULT_MESSAGE;
+
+  if (Platform.OS === 'web') {
+    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+      window.alert(`${drill.name}\n\n${message}`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn('Unable to display drill description: alert is not available.');
+    }
+    return;
+  }
+
+  Alert.alert(drill.name, message);
+}


### PR DESCRIPTION
## Summary
- ensure drill description popups work on the web via a shared helper
- reuse the helper in practice and template forms so drill names open the dialog consistently
- add "View Description" buttons to read-only practice and template views for quick access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c84fd7054c8323b2438e323f009d7c