### PR TITLE
Add safe area handling for classic Android system bars

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,18 @@
 import { Stack } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { DataProvider } from '../src/contexts/DataContext';
 import Header from '../src/components/Header';
 
 export default function RootLayout() {
   return (
     <DataProvider>
-      <Stack screenOptions={{ header: () => <Header /> }} />
+      <SafeAreaProvider>
+        <StatusBar translucent={false} style="auto" />
+        <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
+          <Stack screenOptions={{ header: () => <Header /> }} />
+        </SafeAreaView>
+      </SafeAreaProvider>
     </DataProvider>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,10 @@
 import { Link, usePathname } from 'expo-router';
 import { View, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function Header() {
   const pathname = usePathname();
+  const insets = useSafeAreaInsets();
   let listLink = null;
   if (pathname.startsWith('/teams') && pathname !== '/teams') {
     listLink = (
@@ -25,7 +27,7 @@ export default function Header() {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top, height: 60 + insets.top }]}>
       <Link href="/" style={styles.link}>
         Home
       </Link>
@@ -36,11 +38,11 @@ export default function Header() {
 
 const styles = StyleSheet.create({
   container: {
-    height: 60,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingHorizontal: 16,
+    height: 60,
   },
   link: {
     fontSize: 18,


### PR DESCRIPTION
## Summary
- wrap the app stack with SafeAreaProvider/SafeAreaView and render a non-translucent StatusBar
- pad the custom header with the top safe-area inset to keep it out of the status bar

## Testing
- npm run lint *(warns about existing unused eslint-disable directive)*

------
https://chatgpt.com/codex/tasks/task_b_68c86a77e2848323973cfe084262acc0