### PR TITLE
Fix Android system bar styling

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,8 +15,14 @@
       "predictiveBackGestureEnabled": false
     },
     "androidStatusBar": {
-      "translucent": false
-    },    
+      "translucent": false,
+      "barStyle": "light-content",
+      "backgroundColor": "#000000"
+    },
+    "androidNavigationBar": {
+      "barStyle": "light-content",
+      "backgroundColor": "#000000"
+    },
     "web": {
       "bundler": "metro",
       "output": "static",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,15 +1,32 @@
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import * as SystemUI from 'expo-system-ui';
 import { DataProvider } from '../src/contexts/DataContext';
 import Header from '../src/components/Header';
 
 export default function RootLayout() {
+  useEffect(() => {
+    if (Platform.OS === 'android') {
+      SystemUI.setBackgroundColorAsync('#000000').catch(() => {
+        // Ignore failures when the system UI module is unavailable.
+      });
+    }
+  }, []);
+
+  const statusBarStyle = Platform.OS === 'android' ? 'light' : 'auto';
+
   return (
     <DataProvider>
       <SafeAreaProvider>
-        <StatusBar translucent={false} style="auto" />
-        <SafeAreaView style={{ flex: 1 }} edges={['bottom']}>
+        <StatusBar
+          translucent={false}
+          style={statusBarStyle}
+          backgroundColor={Platform.OS === 'android' ? '#000000' : undefined}
+        />
+        <SafeAreaView style={{ flex: 1, backgroundColor: '#ffffff' }} edges={['bottom']}>
           <Stack screenOptions={{ header: () => <Header /> }} />
         </SafeAreaView>
       </SafeAreaProvider>

--- a/src/utils/showDrillDescription.ts
+++ b/src/utils/showDrillDescription.ts
@@ -14,7 +14,6 @@ export function showDrillDescription(drill?: Pick<Drill, 'name' | 'description'>
     if (typeof window !== 'undefined' && typeof window.alert === 'function') {
       window.alert(`${drill.name}\n\n${message}`);
     } else {
-      // eslint-disable-next-line no-console
       console.warn('Unable to display drill description: alert is not available.');
     }
     return;


### PR DESCRIPTION
## Summary
- set the Android status bar to a dark theme at runtime and in Expo config
- ensure the navigation bar background defaults to solid black instead of translucent
- clean up a redundant lint directive in the drill description helper

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68c86d8badf0832392388ba6a3727100