### PR TITLE
Add Android backup folder workflow

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ChangeEvent } from 'react';
 import {
   StyleSheet,
@@ -13,6 +13,26 @@ import * as FileSystem from 'expo-file-system/legacy';
 import * as DocumentPicker from 'expo-document-picker';
 import { shareAsync } from 'expo-sharing';
 import { useData } from '../src/contexts/DataContext';
+import {
+  BackupFileNotFoundError,
+  BackupPermissionError,
+  chooseBackupFolder,
+  getBackupDirUri,
+  loadBackupJson,
+  saveBackupJson,
+  setBackupDirUri as persistBackupDirUri,
+} from '../src/features/backup';
+
+const BACKUP_FILE_NAME = 'practice-planner.json';
+
+function getProviderAuthority(uri?: string | null) {
+  if (!uri) return null;
+  const match = /^content:\/\/([^/]+)/.exec(uri);
+  if (match) {
+    return match[1];
+  }
+  return null;
+}
 
 function formatForFileName(date: Date) {
   const pad = (value: number) => value.toString().padStart(2, '0');
@@ -32,6 +52,15 @@ function getErrorMessage(error: unknown) {
 export default function HomeScreen() {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const { exportAllData, importAllData } = useData();
+  const [backupDirUri, setBackupDirUriState] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    getBackupDirUri()
+      .then((uri) => setBackupDirUriState(uri ?? undefined))
+      .catch(() => {});
+  }, []);
 
   const showMessage = (title: string, message?: string) => {
     if (Platform.OS === 'web') {
@@ -46,6 +75,146 @@ export default function HomeScreen() {
 
   const showError = (title: string, error: unknown) => {
     showMessage(title, getErrorMessage(error));
+  };
+
+  const ensureBackupFolder = async () => {
+    let uri = backupDirUri;
+    if (uri) return uri;
+
+    try {
+      const stored = await getBackupDirUri();
+      if (stored) {
+        setBackupDirUriState(stored);
+        return stored;
+      }
+    } catch (error) {
+      showError('Unable to access backup settings', error);
+      return undefined;
+    }
+
+    try {
+      const selected = await chooseBackupFolder();
+      if (selected) {
+        setBackupDirUriState(selected);
+        return selected;
+      }
+    } catch (error) {
+      showError('Unable to open folder picker', error);
+    }
+
+    return undefined;
+  };
+
+  const handleSetBackupFolder = async () => {
+    try {
+      const uri = await chooseBackupFolder(backupDirUri);
+      if (!uri) return;
+      setBackupDirUriState(uri);
+      const authority = getProviderAuthority(uri);
+      showMessage(
+        'Backup folder set',
+        authority
+          ? `Future saves and loads will use the folder provided by ${authority}.`
+          : 'Future saves and loads will use the selected folder.',
+      );
+    } catch (error) {
+      showError('Unable to open folder picker', error);
+    }
+  };
+
+  const handleSaveToFolder = async () => {
+    if (Platform.OS !== 'android') {
+      showMessage('Not supported', 'Backup folders are only available on Android.');
+      return;
+    }
+
+    try {
+      const directoryUri = await ensureBackupFolder();
+      if (!directoryUri) return;
+
+      const snapshot = exportAllData();
+      const payload = JSON.stringify(snapshot, null, 2);
+      const result = await saveBackupJson(BACKUP_FILE_NAME, payload);
+      const authority = getProviderAuthority(result.directoryUri);
+      showMessage(
+        'Backup saved',
+        authority
+          ? `Saved ${BACKUP_FILE_NAME} to ${authority}.`
+          : `Saved ${BACKUP_FILE_NAME} to your backup folder.`,
+      );
+    } catch (error) {
+      if (error instanceof BackupPermissionError) {
+        setBackupDirUriState(undefined);
+        await persistBackupDirUri(undefined);
+        showMessage(
+          'Backup folder access lost',
+          'We no longer have permission to use your backup folder. Please choose it again.',
+        );
+        return;
+      }
+      showError('Save failed', error);
+    }
+  };
+
+  const performLoadFromFolder = async () => {
+    if (Platform.OS !== 'android') {
+      showMessage('Not supported', 'Backup folders are only available on Android.');
+      return;
+    }
+
+    try {
+      const directoryUri = await ensureBackupFolder();
+      if (!directoryUri) return;
+
+      const result = await loadBackupJson(BACKUP_FILE_NAME);
+      try {
+        const parsed = JSON.parse(result.contents);
+        importAllData(parsed);
+        const authority = getProviderAuthority(result.directoryUri);
+        showMessage(
+          'Backup loaded',
+          authority
+            ? `Replaced your data from ${BACKUP_FILE_NAME} stored in ${authority}.`
+            : `Replaced your data from ${BACKUP_FILE_NAME}.`,
+        );
+      } catch (error) {
+        showError('Load failed', error);
+      }
+    } catch (error) {
+      if (error instanceof BackupPermissionError) {
+        setBackupDirUriState(undefined);
+        await persistBackupDirUri(undefined);
+        showMessage(
+          'Backup folder access lost',
+          'We no longer have permission to use your backup folder. Please choose it again.',
+        );
+        return;
+      }
+      if (error instanceof BackupFileNotFoundError) {
+        showMessage(
+          'Backup file not found',
+          `Could not find ${error.fileName} in the selected folder.`,
+        );
+        return;
+      }
+      showError('Load failed', error);
+    }
+  };
+
+  const handleLoadFromFolder = () => {
+    const warning =
+      'Loading from your backup folder will overwrite all teams, drills, practices, and templates.';
+
+    Alert.alert('Replace all data?', warning, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Load',
+        style: 'destructive',
+        onPress: () => {
+          void performLoadFromFolder();
+        },
+      },
+    ]);
   };
 
   const handleImportContent = (text: string) => {
@@ -183,6 +352,45 @@ export default function HomeScreen() {
           Export all teams, drills, practices, and templates to a JSON file, or
           replace everything from an existing backup.
         </Text>
+        {Platform.OS === 'android' ? (
+          <>
+            <Text style={styles.sectionSubtitle}>Android backup folder</Text>
+            <Text style={styles.statusText}>
+              {backupDirUri
+                ? (() => {
+                    const authority = getProviderAuthority(backupDirUri);
+                    return authority
+                      ? `Using folder from ${authority}.`
+                      : 'Using your selected backup folder.';
+                  })()
+                : 'No backup folder selected yet.'}
+            </Text>
+            <Text style={styles.noteText}>
+              Saves use {BACKUP_FILE_NAME}. The file will be replaced each time you tap
+              Save.
+            </Text>
+            <Button
+              title={backupDirUri ? 'Change Backup Folder' : 'Set Backup Folder'}
+              onPress={() => {
+                void handleSetBackupFolder();
+              }}
+            />
+            <View style={styles.buttonSpacer} />
+            <Button
+              title="Save to Folder"
+              onPress={() => {
+                void handleSaveToFolder();
+              }}
+            />
+            <View style={styles.buttonSpacer} />
+            <Button
+              title="Load from Folder"
+              color="#d9534f"
+              onPress={handleLoadFromFolder}
+            />
+            <View style={styles.sectionDivider} />
+          </>
+        ) : null}
         <Button title="Export Data" onPress={handleExport} />
         <View style={styles.buttonSpacer} />
         <Button title="Import Data" color="#d9534f" onPress={requestImport} />
@@ -230,12 +438,33 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginBottom: 8,
   },
+  sectionSubtitle: {
+    marginBottom: 8,
+    fontSize: 16,
+    fontWeight: '600',
+  },
   sectionDescription: {
     marginBottom: 16,
     color: '#444444',
     lineHeight: 20,
   },
+  statusText: {
+    marginBottom: 12,
+    color: '#555555',
+  },
+  noteText: {
+    marginBottom: 12,
+    color: '#666666',
+    lineHeight: 18,
+  },
   buttonSpacer: {
     height: 12,
+  },
+  sectionDivider: {
+    marginTop: 16,
+    marginBottom: 20,
+    alignSelf: 'stretch',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#cccccc',
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^15.0.2",
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "^8.4.5",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
@@ -4622,6 +4623,18 @@
         }
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-community/datetimepicker": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.5.tgz",
@@ -5220,7 +5233,7 @@
       "version": "19.1.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -7203,7 +7216,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -10297,6 +10310,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-regex": {
@@ -14403,6 +14425,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "^8.4.5",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",

--- a/src/features/backup.ts
+++ b/src/features/backup.ts
@@ -1,0 +1,167 @@
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as FileSystem from 'expo-file-system/legacy';
+
+const STORAGE_KEY = 'settings.backupDirUri';
+const JSON_MIME_TYPE = 'application/json';
+const DEFAULT_PERMISSION_MESSAGE =
+  'Access to the selected backup folder was revoked. Please choose it again.';
+
+export class BackupFolderNotSetError extends Error {
+  constructor() {
+    super('No backup folder has been selected yet.');
+    this.name = 'BackupFolderNotSetError';
+  }
+}
+
+export class BackupFileNotFoundError extends Error {
+  constructor(public readonly fileName: string) {
+    super(`File not found: ${fileName}`);
+    this.name = 'BackupFileNotFoundError';
+  }
+}
+
+export class BackupPermissionError extends Error {
+  constructor(message = DEFAULT_PERMISSION_MESSAGE) {
+    super(message);
+    this.name = 'BackupPermissionError';
+  }
+}
+
+export type BackupSaveResult = {
+  directoryUri: string;
+  fileUri: string;
+};
+
+export type BackupLoadResult = {
+  directoryUri: string;
+  fileUri: string;
+  contents: string;
+};
+
+function requireSaf(): NonNullable<typeof FileSystem.StorageAccessFramework> {
+  if (Platform.OS !== 'android') {
+    throw new Error('The Storage Access Framework is only available on Android.');
+  }
+
+  const saf = FileSystem.StorageAccessFramework;
+  if (!saf) {
+    throw new Error('Storage Access Framework is not available on this device.');
+  }
+  return saf;
+}
+
+function handleSafError(error: unknown): never {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (
+      message.includes('permission') ||
+      message.includes('access') ||
+      message.includes('denied') ||
+      message.includes('revoked')
+    ) {
+      throw new BackupPermissionError();
+    }
+    throw error;
+  }
+
+  throw new Error('Unexpected Storage Access Framework error.');
+}
+
+async function requireBackupDirUri(): Promise<string> {
+  const directoryUri = await getBackupDirUri();
+  if (!directoryUri) {
+    throw new BackupFolderNotSetError();
+  }
+  return directoryUri;
+}
+
+export async function getBackupDirUri(): Promise<string | undefined> {
+  const value = await AsyncStorage.getItem(STORAGE_KEY);
+  return value ?? undefined;
+}
+
+export async function setBackupDirUri(uri?: string): Promise<void> {
+  if (!uri) {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  await AsyncStorage.setItem(STORAGE_KEY, uri);
+}
+
+export async function chooseBackupFolder(
+  initialUri?: string,
+): Promise<string | undefined> {
+  const saf = requireSaf();
+  const result = await saf.requestDirectoryPermissionsAsync(initialUri);
+  if (result.granted && result.directoryUri) {
+    await setBackupDirUri(result.directoryUri);
+    return result.directoryUri;
+  }
+  return undefined;
+}
+
+export async function saveBackupJson(
+  fileName: string,
+  contents: string,
+): Promise<BackupSaveResult> {
+  const saf = requireSaf();
+  const directoryUri = await requireBackupDirUri();
+
+  let entries: string[] = [];
+  try {
+    entries = await saf.readDirectoryAsync(directoryUri);
+  } catch (error) {
+    handleSafError(error);
+  }
+
+  let targetUri = entries.find((uri) => uri.endsWith(`/${fileName}`));
+
+  if (!targetUri) {
+    try {
+      targetUri = await saf.createFileAsync(directoryUri, fileName, JSON_MIME_TYPE);
+    } catch (error) {
+      handleSafError(error);
+    }
+  }
+
+  if (!targetUri) {
+    throw new Error('Unable to resolve the backup file location.');
+  }
+
+  try {
+    await FileSystem.writeAsStringAsync(targetUri, contents, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
+  } catch (error) {
+    handleSafError(error);
+  }
+
+  return { directoryUri, fileUri: targetUri };
+}
+
+export async function loadBackupJson(fileName: string): Promise<BackupLoadResult> {
+  const saf = requireSaf();
+  const directoryUri = await requireBackupDirUri();
+
+  let entries: string[] = [];
+  try {
+    entries = await saf.readDirectoryAsync(directoryUri);
+  } catch (error) {
+    handleSafError(error);
+  }
+
+  const fileUri = entries.find((uri) => uri.endsWith(`/${fileName}`));
+  if (!fileUri) {
+    throw new BackupFileNotFoundError(fileName);
+  }
+
+  try {
+    const contents = await FileSystem.readAsStringAsync(fileUri, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
+    return { directoryUri, fileUri, contents };
+  } catch (error) {
+    handleSafError(error);
+  }
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage-backed helpers for interacting with Android's Storage Access Framework
- surface "Set/Save/Load" backup controls on the home screen using the stored folder
- prompt users when SAF permissions lapse or when the backup file is missing

## Testing
- npm run lint
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68cb39dbc3b083239bcf3599c1d0d978