### PR TITLE
Persist data natively with SQLite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-router": "~6.0.4",
         "expo-sharing": "~14.0.7",
         "expo-splash-screen": "~31.0.10",
+        "expo-sqlite": "~16.0.8",
         "expo-status-bar": "~3.0.8",
         "expo-symbols": "~1.0.7",
         "expo-system-ui": "~6.0.7",
@@ -6209,6 +6210,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -8746,6 +8753,20 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "16.0.8",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-16.0.8.tgz",
+      "integrity": "sha512-xw776gFgH4ZM5oGs0spSLNmkHO/kJ/EuRXGzE4/22yII9EmG84vm7aM/M2aEb8taBTqwhSGYUpkwkRT5YFFmsg==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "expo-status-bar": "~3.0.8",
     "expo-symbols": "~1.0.7",
     "expo-system-ui": "~6.0.7",
+    "expo-sqlite": "~16.0.8",
     "expo-web-browser": "~15.0.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- add the expo-sqlite native dependency for offline persistence
- initialize a key-value table on native platforms and read/write state automatically
- reuse IndexedDB on web while wiring the native SQLite database into the existing data context

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d16208de088323bd751f82ce0166a7